### PR TITLE
Use calibrated device timestamps for each submit

### DIFF
--- a/src/dxvk/dxvk_adapter.h
+++ b/src/dxvk/dxvk_adapter.h
@@ -145,6 +145,10 @@ namespace dxvk {
       return m_capabilities.getMemoryInfo().core.memoryProperties;
     }
 
+    uint32_t getTimestampValidBits() const {
+      return m_capabilities.getTimestampValidBits();
+    }
+
     /**
      * \brief Checks whether the adapter is usable for DXVK
      *

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -84,7 +84,7 @@ namespace dxvk {
   }
   
   
-  Rc<DxvkCommandList> DxvkContext::endRecording(
+  std::pair<Rc<DxvkCommandList>, VkQueryPool*> DxvkContext::endRecording(
     const VkDebugUtilsLabelEXT*       reason) {
     this->endCurrentCommands();
     this->relocateQueuedResources();
@@ -93,6 +93,15 @@ namespace dxvk {
 
     this->submitDescriptorPool(false);
 
+    VkQueryPool* queryPool = m_latencyTracker ? m_latencyTracker->allocSubmitQueryPool() : nullptr;
+    if (queryPool) {
+      m_cmd->cmdResetQueryPool(DxvkCmdBuffer::ExecBuffer, *queryPool, 0, 1);
+      m_cmd->cmdWriteTimestamp(DxvkCmdBuffer::ExecBuffer,
+        VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
+        *queryPool, 0
+      );
+    }
+
     if (unlikely(m_features.test(DxvkContextFeature::DebugUtils))) {
       // Make sure to emit the submission reason always at the very end
       if (reason && reason->pLabelName && reason->pLabelName[0])
@@ -100,7 +109,7 @@ namespace dxvk {
     }
 
     m_cmd->finalize();
-    return std::exchange(m_cmd, nullptr);
+    return std::make_pair(std::exchange(m_cmd, nullptr), queryPool);
   }
 
 
@@ -144,8 +153,9 @@ namespace dxvk {
     if (m_endLatencyTracking && m_latencyTracker)
       m_latencyTracker->notifyCsRenderEnd(m_latencyFrameId);
 
-    m_device->submitCommandList(this->endRecording(reason),
-      m_latencyTracker, m_latencyFrameId, status);
+    auto [cmdList, queryPool] = this->endRecording(reason);
+    m_device->submitCommandList(cmdList,
+      m_latencyTracker, m_latencyFrameId, queryPool, status);
 
     // Ensure that subsequent submissions do not see the tracker.
     // It is important to hide certain internal submissions in

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -7,6 +7,7 @@
 
 #include "dxvk_device.h"
 #include "dxvk_context.h"
+#include "framepacer/dxvk_framepacer.h"
 
 namespace dxvk {
   
@@ -113,14 +114,13 @@ namespace dxvk {
   void DxvkContext::beginLatencyTracking(
     const Rc<DxvkLatencyTracker>&     tracker,
           uint64_t                    frameId) {
-    if (tracker && m_latencyTracker != tracker) {
+    if (tracker) {
       tracker->notifyCsRenderBegin(frameId);
-
-      m_latencyTracker = tracker;
-      m_latencyFrameId = frameId;
-
       m_endLatencyTracking = false;
     }
+
+    m_latencyTracker = tracker;
+    m_latencyFrameId = frameId;
   }
 
 
@@ -150,10 +150,13 @@ namespace dxvk {
     // Ensure that subsequent submissions do not see the tracker.
     // It is important to hide certain internal submissions in
     // case the application is CPU-bound.
+    // The above is not true when using the frame pacer, and in fact
+    // would prevent it from estimating the GPU usage correctly
     if (m_endLatencyTracking) {
-      m_latencyTracker = nullptr;
-      m_latencyFrameId = 0u;
-
+      if (!dynamic_cast<FramePacer*>(m_latencyTracker.ptr())) {
+        m_latencyTracker = nullptr;
+        m_latencyFrameId = 0u;
+      }
       m_endLatencyTracking = false;
     }
 

--- a/src/dxvk/dxvk_context.h
+++ b/src/dxvk/dxvk_context.h
@@ -52,9 +52,9 @@ namespace dxvk {
      * This will not change any context state
      * other than the active command list.
      * \param [in] reason Optional debug label describing the reason
-     * \returns Active command list
+     * \returns Active command list and a query pool for reading the device timestamp
      */
-    Rc<DxvkCommandList> endRecording(
+    std::pair<Rc<DxvkCommandList>, VkQueryPool*> endRecording(
       const VkDebugUtilsLabelEXT*       reason);
 
     /**

--- a/src/dxvk/dxvk_device.cpp
+++ b/src/dxvk/dxvk_device.cpp
@@ -517,13 +517,13 @@ namespace dxvk {
     const Rc<Presenter>&            presenter,
     uint64_t                        firstFrameId ) {
     if (m_options.latencySleep == Tristate::False)
-      return new FramePacer(m_options, firstFrameId);
+      return new FramePacer(this, m_options, firstFrameId);
 
     if (m_options.latencySleep == Tristate::Auto) {
       if (m_features.nvLowLatency2)
         return new DxvkReflexLatencyTrackerNv(presenter);
       else
-        return new FramePacer(m_options, firstFrameId);
+        return new FramePacer(this, m_options, firstFrameId);
     }
 
     return new DxvkBuiltInLatencyTracker(presenter,
@@ -555,9 +555,11 @@ namespace dxvk {
     const Rc<DxvkCommandList>&      commandList,
     const Rc<DxvkLatencyTracker>&   tracker,
           uint64_t                  frameId,
+          VkQueryPool*              queryPool,
           DxvkSubmitStatus*         status) {
     DxvkSubmitInfo submitInfo = { };
     submitInfo.cmdList = commandList;
+    submitInfo.queryPool = queryPool;
 
     DxvkLatencyInfo latencyInfo;
     latencyInfo.tracker = tracker;

--- a/src/dxvk/dxvk_device.h
+++ b/src/dxvk/dxvk_device.h
@@ -586,12 +586,14 @@ namespace dxvk {
      * \param [in] commandList The command list to submit
      * \param [in] tracker Latency tracker
      * \param [in] frameId Frame ID
+     * \param [in] queryPool Query pool to read device timestamp
      * \param [out] status Submission feedback
      */
     void submitCommandList(
       const Rc<DxvkCommandList>&      commandList,
       const Rc<DxvkLatencyTracker>&   tracker,
             uint64_t                  frameId,
+            VkQueryPool*              queryPool,
             DxvkSubmitStatus*         status);
 
     /**

--- a/src/dxvk/dxvk_device_info.cpp
+++ b/src/dxvk/dxvk_device_info.cpp
@@ -180,6 +180,11 @@ namespace dxvk {
   }
 
 
+  uint32_t DxvkDeviceCapabilities::getTimestampValidBits() const {
+    return m_queuesAvailable[m_queueMapping.graphics.family].queueFamilyProperties.timestampValidBits;
+  }
+
+
   void DxvkDeviceCapabilities::logDeviceInfo() {
     // Assume that known features are ordered by extension
     const VkExtensionProperties* extension = nullptr;
@@ -889,7 +894,7 @@ namespace dxvk {
       ENABLE_EXT(khrSwapchainMutableFormat, false),
 
       /* Calibrated timestamps for frame pacing and present_timing */
-      ENABLE_EXT(khrCalibratedTimestamps, true),
+      ENABLE_EXT(khrCalibratedTimestamps, false),
 
       /* Keyed mutex support in wine */
       ENABLE_EXT(khrWin32KeyedMutex, false),

--- a/src/dxvk/dxvk_device_info.cpp
+++ b/src/dxvk/dxvk_device_info.cpp
@@ -40,6 +40,7 @@ namespace dxvk {
     HANDLE_EXT(extSwapchainMaintenance1);          \
     HANDLE_EXT(extTransformFeedback);              \
     HANDLE_EXT(extVertexAttributeDivisor);         \
+    HANDLE_EXT(khrCalibratedTimestamps);           \
     HANDLE_EXT(khrExternalMemoryWin32);            \
     HANDLE_EXT(khrExternalSemaphoreWin32);         \
     HANDLE_EXT(khrLoadStoreOpNone);                \
@@ -886,6 +887,9 @@ namespace dxvk {
 
       /* Mutable format used to change srgb-ness of swapchain views */
       ENABLE_EXT(khrSwapchainMutableFormat, false),
+
+      /* Calibrated timestamps for frame pacing and present_timing */
+      ENABLE_EXT(khrCalibratedTimestamps, true),
 
       /* Keyed mutex support in wine */
       ENABLE_EXT(khrWin32KeyedMutex, false),

--- a/src/dxvk/dxvk_device_info.h
+++ b/src/dxvk/dxvk_device_info.h
@@ -290,6 +290,8 @@ namespace dxvk {
      */
     bool isSuitable(size_t errorSize, char* error);
 
+    uint32_t getTimestampValidBits() const;
+
     /**
      * \brief Logs all enabled extensions and features
      */

--- a/src/dxvk/dxvk_device_info.h
+++ b/src/dxvk/dxvk_device_info.h
@@ -78,6 +78,7 @@ namespace dxvk {
     VkPhysicalDeviceSwapchainMaintenance1FeaturesEXT          extSwapchainMaintenance1        = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SWAPCHAIN_MAINTENANCE_1_FEATURES_EXT };
     VkPhysicalDeviceTransformFeedbackFeaturesEXT              extTransformFeedback            = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_FEATURES_EXT };
     VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT         extVertexAttributeDivisor       = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_FEATURES };
+    VkBool32                                                  khrCalibratedTimestamps         = VK_FALSE;
     VkBool32                                                  khrExternalMemoryWin32          = VK_FALSE;
     VkBool32                                                  khrExternalSemaphoreWin32       = VK_FALSE;
     VkBool32                                                  khrLoadStoreOpNone              = VK_FALSE;
@@ -135,6 +136,7 @@ namespace dxvk {
     VkExtensionProperties extSwapchainMaintenance1          = vk::makeExtension(VK_EXT_SWAPCHAIN_MAINTENANCE_1_EXTENSION_NAME);
     VkExtensionProperties extTransformFeedback              = vk::makeExtension(VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME);
     VkExtensionProperties extVertexAttributeDivisor         = vk::makeExtension(VK_EXT_VERTEX_ATTRIBUTE_DIVISOR_EXTENSION_NAME);
+    VkExtensionProperties khrCalibratedTimestamps           = vk::makeExtension(VK_KHR_CALIBRATED_TIMESTAMPS_EXTENSION_NAME);
     VkExtensionProperties khrExternalMemoryWin32            = vk::makeExtension(VK_KHR_EXTERNAL_MEMORY_WIN32_EXTENSION_NAME);
     VkExtensionProperties khrExternalSemaphoreWin32         = vk::makeExtension(VK_KHR_EXTERNAL_SEMAPHORE_WIN32_EXTENSION_NAME);
     VkExtensionProperties khrLoadStoreOpNone                = vk::makeExtension(VK_KHR_LOAD_STORE_OP_NONE_EXTENSION_NAME);

--- a/src/dxvk/dxvk_latency.h
+++ b/src/dxvk/dxvk_latency.h
@@ -177,7 +177,8 @@ namespace dxvk {
      * \param [in] frameId Associated frame ID
      */
     virtual void notifyGpuExecutionEnd(
-            uint64_t                  frameId) = 0;
+            uint64_t                  frameId,
+            VkQueryPool*              queryPool) = 0;
 
     virtual void notifyGpuPresentBegin(
             uint64_t                  frameId) { }

--- a/src/dxvk/dxvk_latency.h
+++ b/src/dxvk/dxvk_latency.h
@@ -222,6 +222,12 @@ namespace dxvk {
     virtual DxvkLatencyStats getStatistics(
             uint64_t                  frameId) = 0;
 
+
+    virtual VkQueryPool* allocSubmitQueryPool() { return nullptr; }
+
+    virtual void freeSubmitQueryPool(
+            VkQueryPool*              queryPool ) { }
+
   private:
 
     std::atomic<uint64_t> m_refCount = { 0u };

--- a/src/dxvk/dxvk_latency_builtin.cpp
+++ b/src/dxvk/dxvk_latency_builtin.cpp
@@ -129,7 +129,8 @@ namespace dxvk {
 
 
   void DxvkBuiltInLatencyTracker::notifyGpuExecutionEnd(
-          uint64_t                  frameId) {
+          uint64_t                  frameId,
+          VkQueryPool*              queryPool) {
     std::unique_lock lock(m_mutex);
     auto frame = findFrame(frameId);
 

--- a/src/dxvk/dxvk_latency_builtin.h
+++ b/src/dxvk/dxvk_latency_builtin.h
@@ -64,7 +64,8 @@ namespace dxvk {
             uint64_t                  frameId);
 
     void notifyGpuExecutionEnd(
-            uint64_t                  frameId);
+            uint64_t                  frameId,
+            VkQueryPool*              queryPool);
 
     void notifyGpuPresentEnd(
             uint64_t                  frameId);

--- a/src/dxvk/dxvk_latency_reflex.cpp
+++ b/src/dxvk/dxvk_latency_reflex.cpp
@@ -182,7 +182,8 @@ namespace dxvk {
 
 
   void DxvkReflexLatencyTrackerNv::notifyGpuExecutionEnd(
-          uint64_t                  frameId) {
+          uint64_t                  frameId,
+          VkQueryPool*              queryPool) {
     std::lock_guard lock(m_mutex);
     auto now = dxvk::high_resolution_clock::now();
 

--- a/src/dxvk/dxvk_latency_reflex.h
+++ b/src/dxvk/dxvk_latency_reflex.h
@@ -83,7 +83,8 @@ namespace dxvk {
             uint64_t                  frameId);
 
     void notifyGpuExecutionEnd(
-            uint64_t                  frameId);
+            uint64_t                  frameId,
+            VkQueryPool*              queryPool);
 
     void notifyGpuPresentEnd(
             uint64_t                  frameId);

--- a/src/dxvk/dxvk_queue.cpp
+++ b/src/dxvk/dxvk_queue.cpp
@@ -208,6 +208,8 @@ namespace dxvk {
         } else {
           Logger::err(str::format("DxvkSubmissionQueue: Command submission failed: ", entry.result));
           m_lastError = entry.result;
+          if (entry.latency.tracker)
+            entry.latency.tracker->freeSubmitQueryPool(entry.submit.queryPool);
 
           if (m_lastError != VK_ERROR_DEVICE_LOST)
             m_device->waitForIdle();
@@ -266,8 +268,11 @@ namespace dxvk {
 
           status = vk->vkWaitSemaphores(vk->device(), &waitInfo, ~0ull);
 
-          if (entry.latency.tracker && status == VK_SUCCESS)
-            entry.latency.tracker->notifyGpuExecutionEnd(entry.latency.frameId);
+          if (entry.latency.tracker) {
+            if (status == VK_SUCCESS)
+              entry.latency.tracker->notifyGpuExecutionEnd(entry.latency.frameId, entry.submit.queryPool);
+            else entry.latency.tracker->freeSubmitQueryPool(entry.submit.queryPool);
+          }
         }
 
         if (status != VK_SUCCESS) {

--- a/src/dxvk/dxvk_queue.h
+++ b/src/dxvk/dxvk_queue.h
@@ -33,6 +33,7 @@ namespace dxvk {
    */
   struct DxvkSubmitInfo {
     Rc<DxvkCommandList> cmdList;
+    VkQueryPool*        queryPool;
   };
   
   

--- a/src/dxvk/framepacer/dxvk_calibrated_device_timestamps.cpp
+++ b/src/dxvk/framepacer/dxvk_calibrated_device_timestamps.cpp
@@ -1,0 +1,51 @@
+#include "dxvk_calibrated_device_timestamps.h"
+#include "../dxvk_device.h"
+
+namespace dxvk {
+
+  CalibratedDeviceTimestamps::CalibratedDeviceTimestamps( DxvkDevice* device )
+    : m_device(device),
+      m_timestampPeriod(device->adapter()->deviceProperties().core.properties.limits.timestampPeriod) { }
+
+
+    void CalibratedDeviceTimestamps::calibrate() {
+
+      Calibration nextCalibration;
+
+      // we are only interested in the device "now" timestamp via Vulkan
+      // because getting the host timestamp directly proved to be more reliable
+      VkCalibratedTimestampInfoKHR calibratedTimestampInfo;
+      calibratedTimestampInfo.sType = VK_STRUCTURE_TYPE_CALIBRATED_TIMESTAMP_INFO_KHR;
+      calibratedTimestampInfo.pNext = nullptr;
+      calibratedTimestampInfo.timeDomain = VK_TIME_DOMAIN_DEVICE_KHR;
+
+      VkResult res = m_device->vkd()->vkGetCalibratedTimestampsKHR(
+        m_device->handle(), 1,
+        &calibratedTimestampInfo,
+        &nextCalibration.deviceTimestamp,
+        &nextCalibration.maxDeviation
+      );
+
+      nextCalibration.hostTimestamp = high_resolution_clock::now();
+
+      if (unlikely(res != VK_SUCCESS)) {
+        Logger::err( "Failed to calibrate timestamp" );
+        return;
+      }
+
+      m_calibration = nextCalibration;
+
+    }
+
+
+    CalibratedDeviceTimestamps::time_point CalibratedDeviceTimestamps::getHostTimestamp( uint64_t deviceTimestamp ) {
+
+      int64_t deltaDeviceTicks = deviceTimestamp - m_calibration.deviceTimestamp;
+      int64_t deltaDeviceNanoseconds = deltaDeviceTicks * m_timestampPeriod;
+
+      return m_calibration.hostTimestamp + high_resolution_clock::nanoseconds( deltaDeviceNanoseconds );
+
+    }
+
+
+}

--- a/src/dxvk/framepacer/dxvk_calibrated_device_timestamps.cpp
+++ b/src/dxvk/framepacer/dxvk_calibrated_device_timestamps.cpp
@@ -1,51 +1,91 @@
 #include "dxvk_calibrated_device_timestamps.h"
 #include "../dxvk_device.h"
+#include <vector>
 
 namespace dxvk {
 
   CalibratedDeviceTimestamps::CalibratedDeviceTimestamps( DxvkDevice* device )
-    : m_device(device),
-      m_timestampPeriod(device->adapter()->deviceProperties().core.properties.limits.timestampPeriod) { }
+  : m_device(device),
+    m_timestampPeriod(device->adapter()->deviceProperties().core.properties.limits.timestampPeriod),
+    m_timestampValidBits(device->adapter()->getTimestampValidBits()),
+    m_enabled( m_device->vki()->vkGetPhysicalDeviceCalibrateableTimeDomainsKHR != nullptr &&
+               m_device->vkd()->vkGetCalibratedTimestampsKHR != nullptr &&
+               m_timestampValidBits == 64 ) {
 
-
-    void CalibratedDeviceTimestamps::calibrate() {
-
-      Calibration nextCalibration;
-
-      // we are only interested in the device "now" timestamp via Vulkan
-      // because getting the host timestamp directly proved to be more reliable
-      VkCalibratedTimestampInfoKHR calibratedTimestampInfo;
-      calibratedTimestampInfo.sType = VK_STRUCTURE_TYPE_CALIBRATED_TIMESTAMP_INFO_KHR;
-      calibratedTimestampInfo.pNext = nullptr;
-      calibratedTimestampInfo.timeDomain = VK_TIME_DOMAIN_DEVICE_KHR;
-
-      VkResult res = m_device->vkd()->vkGetCalibratedTimestampsKHR(
-        m_device->handle(), 1,
-        &calibratedTimestampInfo,
-        &nextCalibration.deviceTimestamp,
-        &nextCalibration.maxDeviation
-      );
-
-      nextCalibration.hostTimestamp = high_resolution_clock::now();
-
-      if (unlikely(res != VK_SUCCESS)) {
-        Logger::err( "Failed to calibrate timestamp" );
-        return;
-      }
-
-      m_calibration = nextCalibration;
-
+    if (m_device->vki()->vkGetPhysicalDeviceCalibrateableTimeDomainsKHR == nullptr ||
+        m_device->vkd()->vkGetCalibratedTimestampsKHR == nullptr) {
+      Logger::warn( "VK_KHR_calibrated_timestamps is not enabled. Frame pacing will be suboptimal." );
+      return;
     }
 
-
-    CalibratedDeviceTimestamps::time_point CalibratedDeviceTimestamps::getHostTimestamp( uint64_t deviceTimestamp ) {
-
-      int64_t deltaDeviceTicks = deviceTimestamp - m_calibration.deviceTimestamp;
-      int64_t deltaDeviceNanoseconds = deltaDeviceTicks * m_timestampPeriod;
-
-      return m_calibration.hostTimestamp + high_resolution_clock::nanoseconds( deltaDeviceNanoseconds );
-
+    if (m_timestampValidBits != 64) {
+      Logger::warn( str::format("VK_KHR_calibrated_timestamps is not enabled due to the device queue reporting ",
+        m_timestampValidBits, " bit timestamps. Currently only implemented support for 64 bit timestamps. ",
+        "Frame pacing will be suboptimal."));
+      return;
     }
+
+    uint32_t count;
+    m_device->vki()->vkGetPhysicalDeviceCalibrateableTimeDomainsKHR(m_device->adapter()->handle(), &count, nullptr);
+    std::vector<VkTimeDomainKHR> timeDomains( count );
+    m_device->vki()->vkGetPhysicalDeviceCalibrateableTimeDomainsKHR(m_device->adapter()->handle(), &count, timeDomains.data());
+    bool foundDeviceTimeDomain = false;
+    for (uint32_t i=0; i<count; ++i ) {
+      foundDeviceTimeDomain |= timeDomains[i] == VK_TIME_DOMAIN_DEVICE_KHR;
+    }
+
+    if (!foundDeviceTimeDomain)
+      Logger::err( str::format(
+        "VK_TIME_DOMAIN_DEVICE_KHR is not reported by vkGetPhysicalDeviceCalibrateableTimeDomainsKHR(), ",
+        "possibly a Vulkan driver bug" ) );
+
+    calibrate();
+
+  }
+
+
+  void CalibratedDeviceTimestamps::calibrate() {
+
+    Calibration nextCalibration;
+
+    // we are only interested in the device "now" timestamp via Vulkan
+    // since getting the host timestamp directly proved to be more reliable
+    // possibly because of how the GPU driver interacts with Wine
+    VkCalibratedTimestampInfoKHR calibratedTimestampInfo;
+    calibratedTimestampInfo.sType = VK_STRUCTURE_TYPE_CALIBRATED_TIMESTAMP_INFO_KHR;
+    calibratedTimestampInfo.pNext = nullptr;
+    calibratedTimestampInfo.timeDomain = VK_TIME_DOMAIN_DEVICE_KHR;
+
+    VkResult res = m_device->vkd()->vkGetCalibratedTimestampsKHR(
+      m_device->handle(), 1,
+      &calibratedTimestampInfo,
+      &nextCalibration.deviceTimestamp,
+      &nextCalibration.maxDeviation
+    );
+
+    nextCalibration.hostTimestamp = high_resolution_clock::now();
+
+    if (unlikely(res != VK_SUCCESS)) {
+      Logger::err( "Failed to calibrate timestamp" );
+      return;
+    }
+
+    m_calibration = nextCalibration;
+
+  }
+
+
+  CalibratedDeviceTimestamps::time_point CalibratedDeviceTimestamps::getHostTimestamp( uint64_t deviceTimestamp ) const {
+
+    if (unlikely(m_calibration.deviceTimestamp == 0))
+      return time_point{};
+
+    int64_t deltaDeviceTicks = deviceTimestamp - m_calibration.deviceTimestamp;
+    int64_t deltaDeviceNanoseconds = deltaDeviceTicks * m_timestampPeriod;
+
+    return m_calibration.hostTimestamp + high_resolution_clock::nanoseconds( deltaDeviceNanoseconds );
+
+  }
 
 
 }

--- a/src/dxvk/framepacer/dxvk_calibrated_device_timestamps.h
+++ b/src/dxvk/framepacer/dxvk_calibrated_device_timestamps.h
@@ -7,8 +7,15 @@ namespace dxvk {
   class DxvkDevice;
 
   /*
-   * todo: assumes 64 bit timestamps are supported for now
-   * Intended to be used within a single thread, not thread-safe
+   * Clock synchronization for GPU/CPU via the VK_KHR_calibrated_timestamps
+   * device extension. The clocks need to get calibrated regularly, for example
+   * once every frame, to account for clock drift.
+   *
+   * Assumes 64 bit timestamps are supported for now, as lower bit timestamps
+   * would need overflow checks and are impractical since 32 bit timestamps
+   * would wrap back to zero every 4 seconds at nanosecond precision.
+   *
+   * Intended to be used within a single thread, not thread-safe.
    */
 
   class CalibratedDeviceTimestamps {
@@ -18,22 +25,26 @@ namespace dxvk {
     CalibratedDeviceTimestamps( DxvkDevice* device );
     ~CalibratedDeviceTimestamps() { }
 
+    bool isEnabled() const { return m_enabled; }
+
     void calibrate();
-    time_point getHostTimestamp( uint64_t deviceTimestamp );
+    time_point getHostTimestamp( uint64_t deviceTimestamp ) const;
 
   private:
 
     struct Calibration {
       using time_point = high_resolution_clock::time_point;
-      uint64_t deviceTimestamp;
-      uint64_t maxDeviation;
-      time_point hostTimestamp;
+      uint64_t deviceTimestamp  = 0;
+      uint64_t maxDeviation     = 0;
+      time_point hostTimestamp  = time_point{};
     };
 
     DxvkDevice* m_device;
     Calibration m_calibration;
 
-    const float m_timestampPeriod;
+    const float    m_timestampPeriod;
+    const uint32_t m_timestampValidBits;
+    const bool     m_enabled;
 
   };
 

--- a/src/dxvk/framepacer/dxvk_calibrated_device_timestamps.h
+++ b/src/dxvk/framepacer/dxvk_calibrated_device_timestamps.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "../../util/util_time.h"
+
+namespace dxvk {
+
+  class DxvkDevice;
+
+  /*
+   * todo: assumes 64 bit timestamps are supported for now
+   * Intended to be used within a single thread, not thread-safe
+   */
+
+  class CalibratedDeviceTimestamps {
+  public:
+    using time_point = high_resolution_clock::time_point;
+
+    CalibratedDeviceTimestamps( DxvkDevice* device );
+    ~CalibratedDeviceTimestamps() { }
+
+    void calibrate();
+    time_point getHostTimestamp( uint64_t deviceTimestamp );
+
+  private:
+
+    struct Calibration {
+      using time_point = high_resolution_clock::time_point;
+      uint64_t deviceTimestamp;
+      uint64_t maxDeviation;
+      time_point hostTimestamp;
+    };
+
+    DxvkDevice* m_device;
+    Calibration m_calibration;
+
+    const float m_timestampPeriod;
+
+  };
+
+
+}

--- a/src/dxvk/framepacer/dxvk_framepacer.cpp
+++ b/src/dxvk/framepacer/dxvk_framepacer.cpp
@@ -15,11 +15,11 @@ namespace dxvk {
 
 
   FramePacer::FramePacer( DxvkDevice* device, const DxvkOptions& options, uint64_t firstFrameId )
-  : m_latencyMarkersStorage(firstFrameId), m_device(device) {
-    // We'll default to LOW_LATENCY in the draft-PR for now, for demonstration purposes,
-    // highlighting the generally much better input lag and time consistency.
-    // MAX_FRAME_LATENCY has advantages in some games that provide inconsistent
-    // cpu frametimes and is tuned for highest fps which can be relevant in benchmarks.
+  : m_latencyMarkersStorage(firstFrameId), m_device(device), m_calibratedDeviceTimestamps(device) {
+    // We'll default to LOW_LATENCY, which generally provides the best "input lag"
+    // along with time consistency and often appears the smoothest too.
+    // MAX_FRAME_LATENCY can have advantages in some games like God of War that provide inconsistent
+    // cpu frametimes. Also, it's tuned for highest fps which can be relevant in benchmarks.
     FramePacerMode::Mode mode = FramePacerMode::LOW_LATENCY;
     int refreshRate = 0;
 
@@ -102,17 +102,18 @@ namespace dxvk {
     m_frameSync.signalFrameFinished  ( firstFrameId-1 );
     m_frameSync.signalCsFinished     ( firstFrameId );
 
-    VkQueryPoolCreateInfo queryPoolInfo = {};
-    queryPoolInfo.sType = VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO;
-    queryPoolInfo.queryType = VK_QUERY_TYPE_TIMESTAMP;
-    queryPoolInfo.queryCount = 1;
+    if (m_calibratedDeviceTimestamps.isEnabled()) {
+      VkQueryPoolCreateInfo queryPoolInfo = {};
+      queryPoolInfo.sType = VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO;
+      queryPoolInfo.queryType = VK_QUERY_TYPE_TIMESTAMP;
+      queryPoolInfo.queryCount = 1;
 
-    VkQueryPool* queryPools = m_queryPools.getDataUnsafe();
-    for (int i=0; i<256; ++i) {
-      VkResult res = device->vkd()->vkCreateQueryPool(device->handle(), &queryPoolInfo, nullptr, &queryPools[i]);
+      VkQueryPool* queryPools = m_queryPools.getDataUnsafe();
+      for (int i=0; i<256; ++i) {
+        VkResult res = device->vkd()->vkCreateQueryPool(device->handle(), &queryPoolInfo, nullptr, &queryPools[i]);
 
-      if (res != VK_SUCCESS) {
-        Logger::err( str::format( "FramePacer: vkCreateQueryPool returned ", res) );
+        if (res != VK_SUCCESS)
+          throw DxvkError("FramePacer: Failed to create submit query pool");
       }
     }
   }
@@ -122,9 +123,26 @@ namespace dxvk {
     delete m_presentationStats.load();
     delete m_gpuBufferStats.load();
 
-    for (int i=0; i<256; ++i) {
-      m_device->vkd()->vkDestroyQueryPool(m_device->handle(), *m_queryPools.alloc(), nullptr);
+    if (m_calibratedDeviceTimestamps.isEnabled()) {
+      for (int i=0; i<256; ++i) {
+        // calling queryPool.alloc() ensures it's not in use
+        m_device->vkd()->vkDestroyQueryPool(m_device->handle(), *m_queryPools.alloc(), nullptr);
+      }
     }
+  }
+
+
+  VkResult FramePacer::getSubmitQueryPoolResult( VkQueryPool* queryPool, uint64_t* timestamp ) {
+    VkQueryResultFlags flags = VK_QUERY_RESULT_64_BIT | VK_QUERY_RESULT_WAIT_BIT;
+    VkResult res = m_device->vkd()->vkGetQueryPoolResults(
+      m_device->handle(), *queryPool, 0, 1, sizeof(uint64_t),
+      timestamp, sizeof(uint64_t), flags
+    );
+
+    if (unlikely(res != VK_SUCCESS))
+      Logger::err( str::format( "FramePacer: vkGetQueryPoolResults returned ", res) );
+
+    return res;
   }
 
 }

--- a/src/dxvk/framepacer/dxvk_framepacer.cpp
+++ b/src/dxvk/framepacer/dxvk_framepacer.cpp
@@ -2,6 +2,7 @@
 #include "dxvk_framepacer_mode_low_latency.h"
 #include "dxvk_framepacer_mode_min_latency.h"
 #include "dxvk_options.h"
+#include "../dxvk_device.h"
 #include "../../util/util_flush.h"
 #include "../../util/util_env.h"
 #include "../../util/log/log.h"
@@ -13,8 +14,8 @@ namespace dxvk {
   }
 
 
-  FramePacer::FramePacer( const DxvkOptions& options, uint64_t firstFrameId )
-  : m_latencyMarkersStorage(firstFrameId) {
+  FramePacer::FramePacer( DxvkDevice* device, const DxvkOptions& options, uint64_t firstFrameId )
+  : m_latencyMarkersStorage(firstFrameId), m_device(device) {
     // We'll default to LOW_LATENCY in the draft-PR for now, for demonstration purposes,
     // highlighting the generally much better input lag and time consistency.
     // MAX_FRAME_LATENCY has advantages in some games that provide inconsistent
@@ -100,12 +101,30 @@ namespace dxvk {
     m_frameSync.signalRenderFinished ( firstFrameId-1 );
     m_frameSync.signalFrameFinished  ( firstFrameId-1 );
     m_frameSync.signalCsFinished     ( firstFrameId );
+
+    VkQueryPoolCreateInfo queryPoolInfo = {};
+    queryPoolInfo.sType = VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO;
+    queryPoolInfo.queryType = VK_QUERY_TYPE_TIMESTAMP;
+    queryPoolInfo.queryCount = 1;
+
+    VkQueryPool* queryPools = m_queryPools.getDataUnsafe();
+    for (int i=0; i<256; ++i) {
+      VkResult res = device->vkd()->vkCreateQueryPool(device->handle(), &queryPoolInfo, nullptr, &queryPools[i]);
+
+      if (res != VK_SUCCESS) {
+        Logger::err( str::format( "FramePacer: vkCreateQueryPool returned ", res) );
+      }
+    }
   }
 
 
   FramePacer::~FramePacer() {
     delete m_presentationStats.load();
     delete m_gpuBufferStats.load();
+
+    for (int i=0; i<256; ++i) {
+      m_device->vkd()->vkDestroyQueryPool(m_device->handle(), *m_queryPools.alloc(), nullptr);
+    }
   }
 
 }

--- a/src/dxvk/framepacer/dxvk_framepacer.h
+++ b/src/dxvk/framepacer/dxvk_framepacer.h
@@ -121,6 +121,8 @@ namespace dxvk {
       }
 
       auto t = m_calibratedDeviceTimestamps.getHostTimestamp(timestamp);
+      if (unlikely(t == high_resolution_clock::time_point{}))
+        t = high_resolution_clock::now();
 
       m->gpuReady.push_back(t);
       m_mode->notifyGpuReady(frameId, t);
@@ -150,7 +152,7 @@ namespace dxvk {
     }
 
     VkQueryPool* allocSubmitQueryPool() override
-      { return m_queryPools.alloc(); }
+      { return m_calibratedDeviceTimestamps.isEnabled() ? m_queryPools.alloc() : nullptr; }
 
     void freeSubmitQueryPool( VkQueryPool* queryPool ) override
       { m_queryPools.free( queryPool ); }

--- a/src/dxvk/framepacer/dxvk_framepacer.h
+++ b/src/dxvk/framepacer/dxvk_framepacer.h
@@ -22,6 +22,7 @@ namespace dxvk {
 
   class FramePacer : public DxvkLatencyTracker {
     using microseconds = std::chrono::microseconds;
+    using time_point   = high_resolution_clock::time_point;
   public:
 
     FramePacer( const DxvkOptions& options, uint64_t firstFrameId );
@@ -70,7 +71,6 @@ namespace dxvk {
         auto now = high_resolution_clock::now();
         LatencyMarkers* m = m_latencyMarkersStorage.getMarkers(frameId);
         LatencyMarkers* next = m_latencyMarkersStorage.getMarkers(frameId+1);
-        m->gpuSubmit.push_back(now);
         m->cpuFinished = std::chrono::duration_cast<microseconds>(now - m->start).count();
         next->gpuSubmit.clear();
 
@@ -91,8 +91,6 @@ namespace dxvk {
         auto now = high_resolution_clock::now();
         LatencyMarkers* m = m_latencyMarkersStorage.getMarkers(frameId);
         LatencyMarkers* next = m_latencyMarkersStorage.getMarkers(frameId+1);
-        m->gpuQueueSubmit.push_back(now);
-        m_mode->notifyQueueSubmit(frameId, now);
         next->gpuQueueSubmit.clear();
         queueSubmitCheckGpuStart(frameId, m, now);
       }
@@ -108,18 +106,16 @@ namespace dxvk {
     virtual void notifyGpuPresentBegin( uint64_t frameId ) override {
       // we get frameId == 0 for repeated presents (SyncInterval)
       if (frameId != 0) {
-        auto now = high_resolution_clock::now();
-
         LatencyMarkers* m = m_latencyMarkersStorage.getMarkers(frameId);
         LatencyMarkers* next = m_latencyMarkersStorage.getMarkers(frameId+1);
-        m->gpuReady.push_back(now);
-        m_mode->notifyGpuReady(frameId, now);
-        m->gpuFinished = std::chrono::duration_cast<microseconds>(now - m->start).count();
+        assert( !m->gpuReady.empty() );
+        auto t = m->gpuReady.back();
+        m->gpuFinished = std::chrono::duration_cast<microseconds>(t - m->start).count();
         next->gpuReady.clear();
-        next->gpuReady.push_back(now);
-        m_mode->notifyGpuReady(frameId+1, now);
+        next->gpuReady.push_back(t);
+        m_mode->notifyGpuReady(frameId+1, t);
 
-        gpuExecutionCheckGpuStart(frameId+1, next, now);
+        gpuExecutionCheckGpuStart(frameId+1, next, t);
 
         m_latencyMarkersStorage.m_timeline.gpuFinished.store(frameId);
         m_mode->finishRender(frameId);
@@ -173,20 +169,20 @@ namespace dxvk {
 
   private:
 
-    void signalGpuStart( uint64_t frameId, LatencyMarkers* m, const high_resolution_clock::time_point& t ) {
+    void signalGpuStart( uint64_t frameId, LatencyMarkers* m, const time_point& t ) {
       m->gpuStart = std::chrono::duration_cast<microseconds>(t - m->start).count();
       m_latencyMarkersStorage.m_timeline.gpuStart.store(frameId);
       m_frameSync.signalGpuStart(frameId);
     }
 
-    void queueSubmitCheckGpuStart( uint64_t frameId, LatencyMarkers* m, const high_resolution_clock::time_point& t ) {
+    void queueSubmitCheckGpuStart( uint64_t frameId, LatencyMarkers* m, const time_point& t ) {
       auto& gpuStart = m_gpuStarts[ frameId % m_gpuStarts.size() ];
       uint16_t val = gpuStart.fetch_or(queueSubmitBit);
       if (val == gpuReadyBit)
         signalGpuStart( frameId, m, t );
     }
 
-    void gpuExecutionCheckGpuStart( uint64_t frameId, LatencyMarkers* m, const high_resolution_clock::time_point& t ) {
+    void gpuExecutionCheckGpuStart( uint64_t frameId, LatencyMarkers* m, const time_point& t ) {
       auto& gpuStart = m_gpuStarts[ frameId % m_gpuStarts.size() ];
       uint16_t val = gpuStart.fetch_or(gpuReadyBit);
       if (val == queueSubmitBit)

--- a/src/dxvk/framepacer/dxvk_framepacer.h
+++ b/src/dxvk/framepacer/dxvk_framepacer.h
@@ -4,6 +4,7 @@
 #include "dxvk_frame_sync.h"
 #include "dxvk_latency_markers.h"
 #include "dxvk_latency_stats.h"
+#include "dxvk_calibrated_device_timestamps.h"
 #include "../dxvk_latency.h"
 #include "../../util/util_time.h"
 #include "../../util/sync/sync_ringbuffer_allocator.h"
@@ -99,10 +100,31 @@ namespace dxvk {
     }
 
     void notifyGpuExecutionEnd( uint64_t frameId, VkQueryPool* queryPool ) override {
-      auto now = high_resolution_clock::now();
       LatencyMarkers* m = m_latencyMarkersStorage.getMarkers(frameId);
-      m->gpuReady.push_back(now);
-      m_mode->notifyGpuReady(frameId, now);
+
+      if (unlikely(queryPool == nullptr)) {
+        auto now = high_resolution_clock::now();
+        m->gpuReady.push_back(now);
+        m_mode->notifyGpuReady(frameId, now);
+        return;
+      }
+
+      uint64_t timestamp;
+      VkResult res = getSubmitQueryPoolResult( queryPool, &timestamp );
+
+      if (unlikely(res != VK_SUCCESS)) {
+        auto now = high_resolution_clock::now();
+        m->gpuReady.push_back(now);
+        m_mode->notifyGpuReady(frameId, now);
+        m_queryPools.free(queryPool);
+        return;
+      }
+
+      auto t = m_calibratedDeviceTimestamps.getHostTimestamp(timestamp);
+
+      m->gpuReady.push_back(t);
+      m_mode->notifyGpuReady(frameId, t);
+
       m_queryPools.free(queryPool);
     }
 
@@ -117,6 +139,7 @@ namespace dxvk {
         next->gpuReady.clear();
         next->gpuReady.push_back(t);
         m_mode->notifyGpuReady(frameId+1, t);
+        m_calibratedDeviceTimestamps.calibrate();
 
         gpuExecutionCheckGpuStart(frameId+1, next, t);
 
@@ -166,6 +189,8 @@ namespace dxvk {
 
     // non-overriding methods
 
+
+    VkResult getSubmitQueryPoolResult( VkQueryPool* queryPool, uint64_t* timestamp );
 
     const LatencyStats* getGpuBufferStats() const
       { return m_gpuBufferStats.load(); }
@@ -237,6 +262,7 @@ namespace dxvk {
     std::atomic<LatencyStats*> m_gpuBufferStats = { nullptr };
     std::atomic<LatencyStats*> m_presentationStats = { nullptr };
 
+    CalibratedDeviceTimestamps m_calibratedDeviceTimestamps;
     sync::RingbufferAllocator<VkQueryPool, 256> m_queryPools;
 
   };

--- a/src/dxvk/framepacer/dxvk_framepacer.h
+++ b/src/dxvk/framepacer/dxvk_framepacer.h
@@ -6,6 +6,7 @@
 #include "dxvk_latency_stats.h"
 #include "../dxvk_latency.h"
 #include "../../util/util_time.h"
+#include "../../util/sync/sync_ringbuffer_allocator.h"
 
 
 namespace dxvk {
@@ -123,6 +124,12 @@ namespace dxvk {
       }
     }
 
+    VkQueryPool* allocSubmitQueryPool() override
+      { return m_queryPools.alloc(); }
+
+    void freeSubmitQueryPool( VkQueryPool* queryPool ) override
+      { m_queryPools.free( queryPool ); }
+
     FramePacerMode::Mode getMode() const {
       return m_mode->m_mode;
     }
@@ -226,6 +233,8 @@ namespace dxvk {
 
     std::atomic<LatencyStats*> m_gpuBufferStats = { nullptr };
     std::atomic<LatencyStats*> m_presentationStats = { nullptr };
+
+    sync::RingbufferAllocator<VkQueryPool, 256> m_queryPools;
 
   };
 

--- a/src/dxvk/framepacer/dxvk_framepacer.h
+++ b/src/dxvk/framepacer/dxvk_framepacer.h
@@ -12,6 +12,7 @@
 namespace dxvk {
 
   struct DxvkOptions;
+  class DxvkDevice;
 
   /* \brief Frame pacer interface managing the CPU - GPU synchronization.
    *
@@ -26,7 +27,7 @@ namespace dxvk {
     using time_point   = high_resolution_clock::time_point;
   public:
 
-    FramePacer( const DxvkOptions& options, uint64_t firstFrameId );
+    FramePacer( DxvkDevice* device, const DxvkOptions& options, uint64_t firstFrameId );
     ~FramePacer();
 
     void sleepAndBeginFrame(
@@ -97,11 +98,12 @@ namespace dxvk {
       }
     }
 
-    void notifyGpuExecutionEnd( uint64_t frameId ) override {
+    void notifyGpuExecutionEnd( uint64_t frameId, VkQueryPool* queryPool ) override {
       auto now = high_resolution_clock::now();
       LatencyMarkers* m = m_latencyMarkersStorage.getMarkers(frameId);
       m->gpuReady.push_back(now);
       m_mode->notifyGpuReady(frameId, now);
+      m_queryPools.free(queryPool);
     }
 
     virtual void notifyGpuPresentBegin( uint64_t frameId ) override {
@@ -225,6 +227,7 @@ namespace dxvk {
       }
     }
 
+    DxvkDevice* m_device;
     std::unique_ptr<FramePacerMode> m_mode;
 
     std::array< std::atomic< uint16_t >, 8 > m_gpuStarts = { };

--- a/src/dxvk/framepacer/dxvk_gpu_progress.h
+++ b/src/dxvk/framepacer/dxvk_gpu_progress.h
@@ -40,7 +40,7 @@ namespace dxvk {
       do {
         desired = expected;
         desired.numSubmitsFinished++;
-      } while (!data->submits.compare_exchange_strong( expected, desired ));
+      } while (!data->submits.compare_exchange_weak( expected, desired ));
 
       if (desired.numSubmitsFinished <= desired.numSubmitsQueued)
         startSubmit( frameId, desired.numSubmitsFinished, t );
@@ -57,7 +57,7 @@ namespace dxvk {
       do {
         desired = expected;
         desired.numSubmitsQueued++;
-      } while (!data->submits.compare_exchange_strong( expected, desired ));
+      } while (!data->submits.compare_exchange_weak( expected, desired ));
 
       if (desired.numSubmitsFinished == desired.numSubmitsQueued)
         startSubmit( frameId, desired.numSubmitsQueued, t );

--- a/src/dxvk/hud/dxvk_hud_item_latency.cpp
+++ b/src/dxvk/hud/dxvk_hud_item_latency.cpp
@@ -20,7 +20,7 @@ namespace dxvk::hud {
       LatencyMarkersReader reader = framePacer->m_latencyMarkersStorage.getReader(100);
       const LatencyMarkers* markers;
       uint32_t count = 0;
-      uint64_t totalLatency = 0;
+      int64_t totalLatency = 0;
       while (reader.getNext(markers)) {
         totalLatency += markers->gpuFinished;
         ++count;
@@ -29,7 +29,7 @@ namespace dxvk::hud {
       if (!count)
         return;
 
-      uint64_t latency = totalLatency / count;
+      int64_t latency = totalLatency / count;
       m_latency = str::format(latency / 1000, ".", (latency/100) % 10, " ms");
     }
   }

--- a/src/dxvk/meson.build
+++ b/src/dxvk/meson.build
@@ -127,6 +127,7 @@ dxvk_src = [
 
   'framepacer/dxvk_framepacer.cpp',
   'framepacer/dxvk_framepacer_mode_low_latency.cpp',
+  'framepacer/dxvk_calibrated_device_timestamps.cpp',
 ]
 
 if platform == 'windows'

--- a/src/util/sync/sync_ringbuffer_allocator.h
+++ b/src/util/sync/sync_ringbuffer_allocator.h
@@ -1,0 +1,99 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <atomic>
+#include "../log/log.h"
+
+
+namespace dxvk::sync {
+
+  /*
+   * Simple and efficient arena allocator, where the first objects that are allocated
+   * are expected to be freed first too. This condition is checked and the user has to care
+   * for correct usage. This allocator is thread-safe.
+   */
+
+  template<typename T, int size>
+  class RingbufferAllocator {
+  public:
+
+    RingbufferAllocator() { }
+    ~RingbufferAllocator() { }
+
+    T* alloc() {
+      Indices expected = m_indices.load();
+      Indices desired;
+
+      high_resolution_clock::time_point allocTime {};
+
+      do {
+        desired = expected;
+        desired.producer = (expected.producer + 1) % size;
+        desired.allocCount++;
+
+        // safe guard, but this allocator is not meant to hit this condition
+        if (unlikely(desired.allocCount > size)) {
+          checkThrowError(allocTime);
+          continue;
+        }
+      } while (!m_indices.compare_exchange_weak( expected, desired ));
+
+      return &m_data[desired.producer];
+    }
+
+    void free(T* data) {
+      if (data == nullptr)
+        return;
+
+      int index = (uintptr_t(data)-uintptr_t(m_data))/sizeof(T);
+
+      Indices expected = m_indices.load();
+      Indices desired;
+
+      if (unlikely(expected.consumer != index)) {
+        Logger::err( str::format( "RingbufferAllocator expected release ",
+          expected.consumer, ", got ", index ) );
+      }
+
+      do {
+        desired = expected;
+        desired.consumer = (index + 1) % size;
+        desired.allocCount--;
+      } while (!m_indices.compare_exchange_weak( expected, desired ));
+
+      if (unlikely(desired.allocCount < 0)) {
+        Logger::err( "RingbufferAllocator allocCount < 0" );
+      }
+    }
+
+    T* getDataUnsafe()
+      { return m_data; }
+
+  private:
+
+    void checkThrowError( high_resolution_clock::time_point& allocTime ) {
+      // adding this check here in case allocating would cause a freeze,
+      // which should never happen, but in case it would, this helps to
+      // quickly identify missing calling free() as the root cause
+      if (allocTime == high_resolution_clock::time_point{} ) {
+        allocTime = high_resolution_clock::now();
+      }
+      auto t2 = high_resolution_clock::now();
+      if (std::chrono::duration_cast<std::chrono::milliseconds>(
+        t2 - allocTime).count() > 1000) {
+        throw DxvkError("RingbufferAllocator could not allocate");
+      }
+    }
+
+    struct Indices {
+      uint16_t producer = 0;
+      uint16_t consumer = 1;
+      int32_t allocCount = 0;
+    };
+
+    std::atomic<Indices> m_indices;
+    T m_data[size];
+  };
+
+}

--- a/src/util/util_time.h
+++ b/src/util/util_time.h
@@ -13,10 +13,11 @@ namespace dxvk {
   struct high_resolution_clock {
     static constexpr bool is_steady = true;
 
-    using rep        = int64_t;
-    using period     = std::nano;
-    using duration   = std::chrono::nanoseconds;
-    using time_point = std::chrono::time_point<high_resolution_clock>;
+    using rep         = int64_t;
+    using period      = std::nano;
+    using nanoseconds = std::chrono::nanoseconds;
+    using duration    = std::chrono::nanoseconds;
+    using time_point  = std::chrono::time_point<high_resolution_clock>;
 
     static inline time_point now() noexcept {
       return get_time_from_counter(get_counter());
@@ -48,6 +49,7 @@ namespace dxvk {
   };
 #else
   struct high_resolution_clock : public std::chrono::high_resolution_clock {
+    using nanoseconds = std::chrono::nanoseconds;
     static inline time_point get_time_from_counter(int64_t counter) {
       return time_point() + duration(counter);
     }

--- a/src/vulkan/vulkan_loader.h
+++ b/src/vulkan/vulkan_loader.h
@@ -160,6 +160,10 @@ namespace dxvk::vk {
     VULKAN_FN(vkSubmitDebugUtilsMessageEXT);
     #endif
 
+    #ifdef VK_KHR_calibrated_timestamps
+    VULKAN_FN(vkGetPhysicalDeviceCalibrateableTimeDomainsKHR);
+    #endif
+
     #ifdef VK_EXT_full_screen_exclusive
     VULKAN_FN(vkGetPhysicalDeviceSurfacePresentModes2EXT);
     #endif
@@ -478,6 +482,10 @@ namespace dxvk::vk {
 
     #ifdef VK_KHR_present_wait
     VULKAN_FN(vkWaitForPresentKHR);
+    #endif
+
+    #ifdef VK_KHR_calibrated_timestamps
+    VULKAN_FN(vkGetCalibratedTimestampsKHR);
     #endif
 
     #ifdef VK_KHR_win32_keyed_mutex


### PR DESCRIPTION
Improves precision and smoothness significantly. 

`VK_KHR_calibrated_timestamps` GPU driver support is required for now for testing purposes. I assume this to be wide-spread, but maybe some devices are not supporting this for which I need to add a fallback mechanism. Also 64 bit device timestamps are assumed to be supported for now.