### PR TITLE
Minor optimizations

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -68,6 +68,7 @@ if platform == 'windows'
       '-static',
       '-static-libgcc',
       '-static-libstdc++',
+      '-lsynchronization',
       # We need to set the section alignment for debug symbols to
       # work properly as well as avoiding a memcpy from the Wine loader.
       '-Wl,--file-alignment=4096',
@@ -99,7 +100,8 @@ if platform == 'windows'
     ]
     link_args += [
       '/FILEALIGN:4096',
-      '/DEBUG:FULL'
+      '/DEBUG:FULL',
+      '-lsynchronization'
     ]
   endif
 

--- a/src/dxvk/dxvk_cs.cpp
+++ b/src/dxvk/dxvk_cs.cpp
@@ -63,35 +63,44 @@ namespace dxvk {
   
   
   DxvkCsChunkPool::~DxvkCsChunkPool() {
-    for (DxvkCsChunk* chunk : m_chunks)
-      delete chunk;
+    DxvkCsChunk* chunk = m_stackTop.load();
+
+    while (chunk != nullptr) {
+      DxvkCsChunk* temp = chunk;
+      chunk = chunk->m_nextCached;
+      delete temp;
+    }
   }
   
   
   DxvkCsChunk* DxvkCsChunkPool::allocChunk(DxvkCsChunkFlags flags) {
-    DxvkCsChunk* chunk = nullptr;
+    DxvkCsChunk* stackTop = m_stackTop.load( std::memory_order_acquire );
 
-    { std::lock_guard<dxvk::mutex> lock(m_mutex);
-      
-      if (m_chunks.size() != 0) {
-        chunk = m_chunks.back();
-        m_chunks.pop_back();
+    do {
+      if (unlikely(stackTop == nullptr)) {
+        DxvkCsChunk* chunk = new DxvkCsChunk();
+        chunk->init(flags);
+        return chunk;
       }
-    }
-    
-    if (!chunk)
-      chunk = new DxvkCsChunk();
-    
-    chunk->init(flags);
-    return chunk;
+    } while (!m_stackTop.compare_exchange_weak( stackTop, stackTop->m_nextCached,
+        std::memory_order_release,
+        std::memory_order_acquire));
+
+    stackTop->m_nextCached = nullptr;
+    stackTop->init(flags);
+    return stackTop;
   }
   
   
   void DxvkCsChunkPool::freeChunk(DxvkCsChunk* chunk) {
     chunk->reset();
-    
-    std::lock_guard<dxvk::mutex> lock(m_mutex);
-    m_chunks.push_back(chunk);
+    DxvkCsChunk* stackTop = m_stackTop.load( std::memory_order_acquire );
+
+    do {
+      chunk->m_nextCached = stackTop;
+    } while (!m_stackTop.compare_exchange_weak( stackTop, chunk,
+        std::memory_order_release,
+        std::memory_order_acquire));
   }
   
   

--- a/src/dxvk/dxvk_cs.h
+++ b/src/dxvk/dxvk_cs.h
@@ -194,7 +194,7 @@ namespace dxvk {
    * Stores a list of commands.
    */
   class DxvkCsChunk : public RcObject {
-
+  friend class DxvkCsChunkPool;
   public:
 
     DxvkCsChunk();
@@ -326,7 +326,8 @@ namespace dxvk {
     DxvkCsCmd** m_next = &m_head;
 
     DxvkCsChunkFlags m_flags;
-    
+    DxvkCsChunk* m_nextCached = nullptr;
+
     alignas(64)
     char m_data[DxvkCsChunkSize];
 
@@ -387,10 +388,10 @@ namespace dxvk {
     void freeChunk(DxvkCsChunk* chunk);
     
   private:
-    
-    dxvk::mutex               m_mutex;
-    std::vector<DxvkCsChunk*> m_chunks;
-    
+
+    alignas(CACHE_LINE_SIZE)
+    std::atomic<DxvkCsChunk*> m_stackTop = { nullptr };
+
   };
   
   

--- a/src/dxvk/dxvk_memory.cpp
+++ b/src/dxvk/dxvk_memory.cpp
@@ -415,22 +415,14 @@ namespace dxvk {
           DxvkResourceAllocation*     allocation) {
     uint32_t poolIndex = DxvkLocalAllocationCache::computePoolIndex(allocation->m_size);
 
-    { std::unique_lock freeLock(m_freeMutex);
-      auto& list = m_freeLists[poolIndex];
+    auto& list = m_freeLists[poolIndex];
+    allocation = list.push(allocation);
 
-      allocation->m_nextCached = list.head;
-      list.head = allocation;
+    if (likely(!allocation))
+      return nullptr;
 
-      if (++list.size < list.capacity)
-        return nullptr;
-
-      // Free list is full, try to add it to the list array
-      // so that subsequent allocations can use it.
-      list.head = nullptr;
-      list.size = 0u;
-    }
-
-    // Add free list to the pool if possible.
+    // Free list is full, add it to the pool if possible, so that
+    // subsequent allocations can use it.
     { std::unique_lock poolLock(m_poolMutex);
       auto& pool = m_pools[poolIndex];
 
@@ -525,6 +517,27 @@ namespace dxvk {
         m_cacheSize -= PoolCapacityInBytes;
       }
     }
+  }
+
+
+  DxvkResourceAllocation* DxvkSharedAllocationCache::FreeList::push( DxvkResourceAllocation* allocation ) {
+    uint16_t expected_size = size.fetch_add(1, std::memory_order_acq_rel) + 1;
+    while (unlikely(expected_size >= capacity)) {
+      if (size.compare_exchange_weak(expected_size, 0)) {
+        DxvkResourceAllocation* res = head.exchange( nullptr );
+        allocation->m_nextCached = res;
+        return allocation;
+      }
+    }
+
+    DxvkResourceAllocation* expected_head = head.load( std::memory_order_acquire );
+    do {
+      allocation->m_nextCached = expected_head;
+    } while (!head.compare_exchange_weak( expected_head, allocation,
+        std::memory_order_release,
+        std::memory_order_acquire));
+
+    return nullptr;
   }
 
 

--- a/src/dxvk/dxvk_memory.h
+++ b/src/dxvk/dxvk_memory.h
@@ -906,10 +906,14 @@ namespace dxvk {
   private:
 
     struct FreeList {
-      uint16_t size = 0u;
+      DxvkResourceAllocation* push( DxvkResourceAllocation* allocation );
+
+      alignas(CACHE_LINE_SIZE)
+      std::atomic<uint16_t> size = { 0u };
       uint16_t capacity = 0u;
 
-      DxvkResourceAllocation* head = nullptr;
+      alignas(CACHE_LINE_SIZE)
+      std::atomic<DxvkResourceAllocation*> head = { nullptr };
     };
 
     struct List {
@@ -923,10 +927,7 @@ namespace dxvk {
       high_resolution_clock::time_point drainTime = { };
     };
 
-    alignas(CACHE_LINE_SIZE)
     DxvkMemoryAllocator*        m_allocator = nullptr;
-
-    dxvk::mutex                 m_freeMutex;
     std::array<FreeList, PoolCount> m_freeLists = { };
 
     alignas(CACHE_LINE_SIZE)

--- a/src/dxvk/framepacer/dxvk_calibrated_device_timestamps.cpp
+++ b/src/dxvk/framepacer/dxvk_calibrated_device_timestamps.cpp
@@ -8,7 +8,7 @@ namespace dxvk {
   : m_device(device),
     m_timestampPeriod(device->adapter()->deviceProperties().core.properties.limits.timestampPeriod),
     m_timestampValidBits(device->adapter()->getTimestampValidBits()),
-    m_enabled( (m_device->features().khrCalibratedTimestamps || m_device->features().extCalibratedTimestamps) &&
+    m_canEnable( (m_device->features().khrCalibratedTimestamps || m_device->features().extCalibratedTimestamps) &&
                m_timestampValidBits == 64 ) {
 
     if (!m_device->features().khrCalibratedTimestamps && !m_device->features().extCalibratedTimestamps) {
@@ -54,6 +54,9 @@ namespace dxvk {
 
 
   void CalibratedDeviceTimestamps::calibrate() {
+
+    if (!m_enabled)
+      return;
 
     Calibration nextCalibration;
 

--- a/src/dxvk/framepacer/dxvk_calibrated_device_timestamps.h
+++ b/src/dxvk/framepacer/dxvk_calibrated_device_timestamps.h
@@ -27,6 +27,7 @@ namespace dxvk {
     CalibratedDeviceTimestamps( DxvkDevice* device );
     ~CalibratedDeviceTimestamps() { }
 
+    void enable() { m_enabled = m_canEnable; }
     bool isEnabled() const { return m_enabled; }
 
     void calibrate();
@@ -43,12 +44,13 @@ namespace dxvk {
 
     DxvkDevice* m_device;
     Calibration m_calibration;
+    bool        m_enabled = false;
 
     PFN_vkGetCalibratedTimestampsKHR m_fpGetCalibratedTimestamps = nullptr;
 
     const float    m_timestampPeriod;
     const uint32_t m_timestampValidBits;
-    const bool     m_enabled;
+    const bool     m_canEnable;
 
   };
 

--- a/src/dxvk/framepacer/dxvk_framepacer.cpp
+++ b/src/dxvk/framepacer/dxvk_framepacer.cpp
@@ -61,6 +61,7 @@ namespace dxvk {
         Logger::info( "Frame pace: low-latency" );
         GpuFlushTracker::m_minPendingSubmissions = 1;
         GpuFlushTracker::m_minChunkCount = 1;
+        m_calibratedDeviceTimestamps.enable();
         m_mode = std::make_unique<LowLatencyMode>(mode, &m_latencyMarkersStorage, &m_frameSync, options, firstFrameId);
         break;
 
@@ -68,6 +69,7 @@ namespace dxvk {
         Logger::info( "Frame pace: low-latency-vrr" );
         GpuFlushTracker::m_minPendingSubmissions = 1;
         GpuFlushTracker::m_minChunkCount = 1;
+        m_calibratedDeviceTimestamps.enable();
         m_mode = std::make_unique<LowLatencyMode>(mode, &m_latencyMarkersStorage, &m_frameSync, options, firstFrameId, refreshRate);
         break;
 

--- a/src/dxvk/framepacer/dxvk_framepacer.h
+++ b/src/dxvk/framepacer/dxvk_framepacer.h
@@ -102,7 +102,7 @@ namespace dxvk {
     void notifyGpuExecutionEnd( uint64_t frameId, VkQueryPool* queryPool ) override {
       LatencyMarkers* m = m_latencyMarkersStorage.getMarkers(frameId);
 
-      if (unlikely(queryPool == nullptr)) {
+      if (queryPool == nullptr) {
         auto now = high_resolution_clock::now();
         m->gpuReady.push_back(now);
         m_mode->notifyGpuReady(frameId, now);
@@ -145,6 +145,7 @@ namespace dxvk {
 
         gpuExecutionCheckGpuStart(frameId+1, next, t);
 
+        m_latencyAverage.push(m->gpuFinished);
         m_latencyMarkersStorage.m_timeline.gpuFinished.store(frameId);
         m_mode->finishRender(frameId);
         m_frameSync.signalRenderFinished(frameId);
@@ -193,6 +194,9 @@ namespace dxvk {
 
 
     VkResult getSubmitQueryPoolResult( VkQueryPool* queryPool, uint64_t* timestamp );
+
+    int32_t getLatencyAverage() const
+      { return m_latencyAverage.getAverage(); }
 
     const LatencyStats* getGpuBufferStats() const
       { return m_gpuBufferStats.load(); }
@@ -263,6 +267,7 @@ namespace dxvk {
 
     std::atomic<LatencyStats*> m_gpuBufferStats = { nullptr };
     std::atomic<LatencyStats*> m_presentationStats = { nullptr };
+    LatencyAverage m_latencyAverage;
 
     CalibratedDeviceTimestamps m_calibratedDeviceTimestamps;
     sync::RingbufferAllocator<VkQueryPool, 256> m_queryPools;

--- a/src/dxvk/framepacer/dxvk_latency_markers.h
+++ b/src/dxvk/framepacer/dxvk_latency_markers.h
@@ -12,7 +12,6 @@
 namespace dxvk {
 
   class FramePacer;
-  class LatencyMarkersStorage;
 
 
   struct LatencyMarkers {
@@ -49,33 +48,17 @@ namespace dxvk {
   };
 
 
-  class LatencyMarkersReader {
-
-  public:
-
-    LatencyMarkersReader( const LatencyMarkersStorage* storage, uint32_t numEntries );
-    bool getNext( const LatencyMarkers*& result );
-
-  private:
-
-    const LatencyMarkersStorage* m_storage;
-    uint64_t m_index;
-
-  };
-
-
   class LatencyMarkersStorage {
-    friend class LatencyMarkersReader;
     friend class FramePacer;
   public:
 
     LatencyMarkersStorage( uint64_t firstFrameId )
-    : m_firstFrameId(firstFrameId) { }
-    ~LatencyMarkersStorage() { }
-
-    LatencyMarkersReader getReader( uint32_t numEntries ) const {
-      return LatencyMarkersReader(this, numEntries);
+    : m_firstFrameId(firstFrameId) {
+      LatencyMarkers* markers = getMarkers(firstFrameId);
+      markers->start = high_resolution_clock::now();
     }
+
+    ~LatencyMarkersStorage() { }
 
     void registerFrameStart( uint64_t frameId ) {
       if (unlikely(frameId <= m_timeline.frameFinished.load())) {
@@ -119,31 +102,12 @@ namespace dxvk {
     }
 
     // simple modulo hash mapping is used for frameIds. They are expected to monotonically increase by one.
-    // select the size large enough, so we never come into a situation where the reader cannot keep up with the producer
-    static constexpr uint16_t m_numMarkers = 128;
+    // only store a small number of past frames to keep the memory footprint low.
+    static constexpr uint16_t m_numMarkers = 4;
     const uint64_t m_firstFrameId;
     std::array<LatencyMarkers, m_numMarkers> m_markers = { };
     LatencyMarkersTimeline m_timeline;
 
   };
-
-
-
-  inline LatencyMarkersReader::LatencyMarkersReader( const LatencyMarkersStorage* storage, uint32_t numEntries )
-  : m_storage(storage) {
-    m_index = 0;
-    if (m_storage->m_timeline.frameFinished.load() > numEntries + storage->m_firstFrameId + 2)
-      m_index = m_storage->m_timeline.frameFinished.load() - numEntries;
-  }
-
-
-  inline bool LatencyMarkersReader::getNext( const LatencyMarkers*& result ) {
-    if (m_index == 0 || m_index > m_storage->m_timeline.frameFinished.load())
-      return false;
-
-    result = &m_storage->m_markers[m_index % m_storage->m_numMarkers];
-    m_index++;
-    return true;
-  }
 
 }

--- a/src/dxvk/framepacer/dxvk_latency_stats.h
+++ b/src/dxvk/framepacer/dxvk_latency_stats.h
@@ -109,4 +109,37 @@ namespace dxvk {
 
   };
 
+
+  class LatencyAverage {
+  public:
+
+    using time_point = high_resolution_clock::time_point;
+
+    void push( int32_t latency ) {
+
+      m_totalLatency -= m_latencies[m_curIndex];
+      m_totalLatency += latency;
+      m_latencies[m_curIndex] = latency;
+      ++m_curIndex;
+
+      m_average.store( m_totalLatency / size, std::memory_order_release );
+
+    }
+
+    int32_t getAverage() const
+      { return m_average.load( std::memory_order_acquire ); }
+
+  private:
+
+    // note this cannot be changed unless m_curIndex is tracked accordingly
+    // as we let it overflow automatically
+    static constexpr size_t size = 256;
+    std::array<int32_t, size> m_latencies = { };
+
+    uint8_t m_curIndex = { 0 };
+    int64_t m_totalLatency = { 0 };
+    std::atomic<int32_t> m_average = { 0 };
+
+  };
+
 }

--- a/src/dxvk/hud/dxvk_hud_item_latency.cpp
+++ b/src/dxvk/hud/dxvk_hud_item_latency.cpp
@@ -17,19 +17,7 @@ namespace dxvk::hud {
     if (elapsed.count() >= UpdateInterval) {
       m_lastUpdate = time;
 
-      LatencyMarkersReader reader = framePacer->m_latencyMarkersStorage.getReader(100);
-      const LatencyMarkers* markers;
-      uint32_t count = 0;
-      int64_t totalLatency = 0;
-      while (reader.getNext(markers)) {
-        totalLatency += markers->gpuFinished;
-        ++count;
-      }
-
-      if (!count)
-        return;
-
-      int64_t latency = totalLatency / count;
+      int32_t latency = framePacer->getLatencyAverage();
       m_latency = str::format(latency / 1000, ".", (latency/100) % 10, " ms");
     }
   }

--- a/src/util/sync/sync_ringbuffer_allocator.h
+++ b/src/util/sync/sync_ringbuffer_allocator.h
@@ -27,7 +27,7 @@ namespace dxvk::sync {
 
       high_resolution_clock::time_point allocTime {};
 
-      do {
+      while (true) {
         desired = expected;
         desired.producer = (expected.producer + 1) % size;
         desired.allocCount++;
@@ -37,9 +37,10 @@ namespace dxvk::sync {
           checkThrowError(allocTime);
           continue;
         }
-      } while (!m_indices.compare_exchange_weak( expected, desired ));
 
-      return &m_data[desired.producer];
+        if (m_indices.compare_exchange_weak( expected, desired ))
+          return &m_data[desired.producer];
+      }
     }
 
     void free(T* data) {

--- a/src/util/sync/sync_signal.h
+++ b/src/util/sync/sync_signal.h
@@ -4,6 +4,10 @@
 #include <functional>
 #include <list>
 
+#ifdef _WIN32
+#include <synchapi.h>
+#endif
+
 #include "../rc/util_rc.h"
 
 #include "../thread.h"
@@ -81,6 +85,7 @@ namespace dxvk::sync {
   };
 
 
+#ifdef _WIN32
   /**
    * \brief Fence
    *
@@ -101,28 +106,24 @@ namespace dxvk::sync {
     }
 
     void signal(uint64_t value) {
-      std::unique_lock<dxvk::mutex> lock(m_mutex);
       m_value.store(value, std::memory_order_release);
-      m_cond.notify_all();
+      WakeByAddressAll(&m_value);
     }
     
     void wait(uint64_t value) {
-      if (value <= m_value.load(std::memory_order_acquire))
-        return;
-
-      std::unique_lock<dxvk::mutex> lock(m_mutex);
-      m_cond.wait(lock, [this, value] {
-        return value <= m_value.load(std::memory_order_acquire);
-      });
+      uint64_t cur = m_value.load(std::memory_order_acquire);
+      while (cur < value) {
+        WaitOnAddress(&m_value, &cur, sizeof(uint64_t), INFINITE);
+        cur = m_value.load(std::memory_order_acquire);
+      }
     }
 
   private:
 
     std::atomic<uint64_t>    m_value;
-    dxvk::mutex              m_mutex;
-    dxvk::condition_variable m_cond;
 
   };
+#endif
 
 
   /**
@@ -199,5 +200,53 @@ namespace dxvk::sync {
     std::list<std::pair<uint64_t, std::function<void ()>>> m_callbacks;
 
   };
+
+
+#ifndef _WIN32
+
+  /**
+   * \brief Fence
+   *
+   * Simple CPU-side fence.
+   */
+  class Fence final : public Signal {
+
+  public:
+
+    Fence()
+    : m_value(0ull) { }
+
+    explicit Fence(uint64_t value)
+    : m_value(value) { }
+
+    uint64_t value() const {
+      return m_value.load(std::memory_order_acquire);
+    }
+
+    void signal(uint64_t value) {
+      std::unique_lock<dxvk::mutex> lock(m_mutex);
+      m_value.store(value, std::memory_order_release);
+      m_cond.notify_all();
+    }
+
+    void wait(uint64_t value) {
+      if (value <= m_value.load(std::memory_order_acquire))
+        return;
+
+      std::unique_lock<dxvk::mutex> lock(m_mutex);
+      m_cond.wait(lock, [this, value] {
+        return value <= m_value.load(std::memory_order_acquire);
+      });
+    }
+
+  private:
+
+    std::atomic<uint64_t>    m_value;
+    dxvk::mutex              m_mutex;
+    dxvk::condition_variable m_cond;
+
+  };
+
+#endif
   
 }


### PR DESCRIPTION
Two commits slightly reduce the overhead of how the frame pacing is collecting timing data.

The other ones target improving (non-)blocking behavior, especially for the game's rendering thread. The most interesting one should be [Optimize DxvkSharedAllocationCache::freeAllocation](https://github.com/netborg-afps/dxvk-low-latency/commit/2006052ae9e134bc9b01d9dd8a0d16618e6ab65c), which was measured to consume a lot of CPU time - because it got called ~10-50 million times per minute in some games - that got drastically reduced. 

However most of this CPU time was happening in the CS thread, so it may not result in much net-performance. Still, this is a safe improvement since there are no downsides to using the improved synchronization, as the flow and ordering of data is maintained. 

The same optimization - transforming a mutex-protected stack to a lock-free stack - is done for the DxvkCsChunkPool. This generated much less overhead than DxvkSharedAllocationCache::freeAllocation, but now it can no longer block which is a good thing.