### PR TITLE
Threaded sleep

### DIFF
--- a/src/dxvk/framepacer/dxvk_framepacer_mode_low_latency.h
+++ b/src/dxvk/framepacer/dxvk_framepacer_mode_low_latency.h
@@ -2,6 +2,7 @@
 
 #include "dxvk_framepacer_mode.h"
 #include "dxvk_gpu_progress.h"
+#include "dxvk_threaded_sleep.h"
 #include "../dxvk_options.h"
 #include "../../util/log/log.h"
 #include "../../util/util_string.h"
@@ -119,7 +120,7 @@ namespace dxvk {
         int32_t maxDelay = std::max( m_fpsLimitFrametime.load(), 20000 );
         time_point maxSleep = m->start + microseconds(maxDelay);
 
-        m_gpuProgress.waitUntil( frameId-1, targetGpuTime, props.cpuUntilGpuStart, maxSleep );
+        m_gpuProgress.waitUntil( frameId-1, targetGpuTime, props.cpuUntilGpuStart, maxSleep, m_threadedSleep );
         lastFrameFinishPrediction = high_resolution_clock::now()
           + microseconds(props.optimizedGpuTime - targetGpuTime);
       }
@@ -350,7 +351,7 @@ namespace dxvk {
       delay = std::min( delay, maxDelay );
 
       Sleep::TimePoint t2 = t + microseconds(delay);
-      Sleep::sleepUntil( t, t2 );
+      m_threadedSleep.sleepUntil(t2);
 
     }
 
@@ -369,6 +370,7 @@ namespace dxvk {
 
     std::vector<int32_t>  m_tempGpuRun;
 
+    ThreadedSleep m_threadedSleep;
     GpuProgress m_gpuProgress;
 
   };

--- a/src/dxvk/framepacer/dxvk_gpu_progress.h
+++ b/src/dxvk/framepacer/dxvk_gpu_progress.h
@@ -3,6 +3,7 @@
 #include <atomic>
 #include <stdint.h>
 #include "dxvk_latency_markers.h"
+#include "dxvk_threaded_sleep.h"
 #include "../../util/log/log.h"
 #include "../../util/util_string.h"
 
@@ -102,7 +103,7 @@ namespace dxvk {
     }
 
 
-    void waitUntil( uint64_t frameId, int32_t targetGpuRuntime, int32_t cpuUntilGpuStart, time_point maxSleep ) const {
+    void waitUntil( uint64_t frameId, int32_t targetGpuRuntime, int32_t cpuUntilGpuStart, time_point maxSleep, ThreadedSleep& threadedSleep ) const {
       // GPU progress is measured as if the submits would be processed as late as possible
       // on the GPU while assuming the frame to be minimum latency since gpuStart.
       // This is necessary for this to work reliably accross games.
@@ -121,7 +122,7 @@ namespace dxvk {
 
       Sleep::TimePoint t = now + microseconds(sleepDelay);
       t = std::min(t, maxSleep);
-      Sleep::sleepUntil( now, t );
+      threadedSleep.sleepUntil( t );
 
       // For the remainder of the frame we check the progress by polling.
       // Usually this will take far less than a millisecond, with the exception

--- a/src/dxvk/framepacer/dxvk_threaded_sleep.h
+++ b/src/dxvk/framepacer/dxvk_threaded_sleep.h
@@ -1,0 +1,92 @@
+#pragma once
+
+#include "../../util/sync/sync_atomic_signal.h"
+#include "../../util/util_sleep.h"
+#include "../../util/thread.h"
+#include <atomic>
+
+
+namespace dxvk {
+
+
+  class ThreadedSleep {
+
+  public:
+
+    using TimePoint = Sleep::TimePoint;
+
+    ThreadedSleep()
+    : m_thread([this] { threadFunc(); })
+    { }
+
+
+    ~ThreadedSleep() {
+
+      m_stopped.store(true);
+      m_start.signal_one();
+      m_thread.join();
+
+    }
+
+
+    void sleepUntil( const TimePoint& t ) {
+
+      constexpr bool threadedSleep = true;
+      if constexpr (!threadedSleep) {
+        Sleep::sleepUntil(high_resolution_clock::now(), t);
+        return;
+      }
+
+      // don't sleep threaded if the sleep duration is too short
+      // setup the wake up early enough so the scheduler "cannot" fail to miss "t"
+
+      TimePoint t2 = t - std::chrono::microseconds(150);
+      if (high_resolution_clock::now() - std::chrono::microseconds(100) < t2) {
+
+        m_t.store(t2);
+        m_start.signal_one();
+        m_finish.wait();
+
+      }
+
+      // spin-wait the remaining microseconds
+
+      TimePoint now;
+      do {
+        now = high_resolution_clock::now();
+      } while (now < t);
+
+    }
+
+
+    void threadFunc() {
+
+      while (!m_stopped.load( std::memory_order_acquire)) {
+
+        m_start.wait();
+        TimePoint t = m_t.load();
+        Sleep::sleepUntil( high_resolution_clock::now(), t );
+        m_finish.signal_one();
+
+      }
+
+      m_finish.signal_one();
+
+    }
+
+  private:
+
+    std::atomic<bool> m_stopped = { false };
+    dxvk::thread m_thread;
+
+    sync::AtomicSignal m_start  = { "m_start", false };
+    sync::AtomicSignal m_finish = { "m_finish", false };
+
+    std::atomic<TimePoint> m_t = { high_resolution_clock::now() };
+
+    static_assert( std::atomic<TimePoint>::is_always_lock_free );
+
+  };
+
+
+}

--- a/src/util/sync/sync_atomic_signal.h
+++ b/src/util/sync/sync_atomic_signal.h
@@ -1,0 +1,186 @@
+#pragma once
+
+#ifdef _WIN32
+
+#include <synchapi.h>
+#include <errhandlingapi.h>
+#include <atomic>
+
+#include "../util_string.h"
+#include "../log/log.h"
+
+//#define _atomic_signal_debug(x) Logger::debug(x)
+#define _atomic_signal_debug(x) void()
+
+namespace dxvk::sync {
+
+  /**
+   * \brief WaitOnAddress based sync implementation
+   */
+  class AtomicSignal {
+
+  public:
+
+    AtomicSignal(const char* name, bool initValue)
+    : m_name(name) {
+      m_flag.store(initValue, std::memory_order_release);
+    }
+
+    ~AtomicSignal() {}
+
+    void wait() {
+      _atomic_signal_debug( std::string("enter wait for ") + m_name );
+
+      while (true) {
+
+        bool _true = true;
+        if (m_flag.load(std::memory_order_acquire)
+        && m_flag.compare_exchange_strong(_true, false, std::memory_order_release, std::memory_order_acquire))
+          break;
+
+        // waits until m_flag becomes != false
+        bool res = WaitOnAddress(&m_flag, (void*) &m_flagFalse, 1, m_infinite);
+
+        if (unlikely(!res))
+          Logger::err(str::format("WaitOnAddress failed. LastError: ", GetLastError()));
+
+      }
+
+      _atomic_signal_debug( std::string("finish wait for ") + m_name );
+    }
+
+    void signal_one() {
+      _atomic_signal_debug( std::string("enter signal_one for ") + m_name );
+
+      bool _false = 0;
+      if (m_flag.compare_exchange_strong(_false, true, std::memory_order_release, std::memory_order_acquire))
+        WakeByAddressSingle(&m_flag);
+
+      _atomic_signal_debug( std::string("finish signal_one for ") + m_name );
+    }
+
+    void signal_all() {
+      _atomic_signal_debug( std::string("enter signal_all for ") + m_name );
+
+      m_flag.store(true, std::memory_order_release);
+      WakeByAddressAll(&m_flag);
+
+      _atomic_signal_debug( std::string("finish signal_all for ") + m_name );
+    }
+
+    void clear() {
+      _atomic_signal_debug( std::string("clear flag for ") + m_name );
+      m_flag.store(false, std::memory_order_release);
+    }
+
+  private:
+
+    alignas(64) std::atomic<bool>       m_flag;
+    const char*                         m_name;
+
+    static constexpr std::atomic<bool>  m_flagFalse = { false };
+    static constexpr uint32_t           m_infinite  = 0xffffffff; // matches INFINITE define in winbase.h
+  };
+
+}
+
+#else
+
+#include <atomic>
+#include <stdint.h>
+#include <climits>
+#include <err.h>
+#include <errno.h>
+#include <linux/futex.h>
+#include <sys/syscall.h>
+#include <sys/time.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "../util_string.h"
+#include "../log/log.h"
+
+static_assert( sizeof(std::atomic<uint32_t>) == sizeof(uint32_t) );
+
+
+static int futex(uint32_t* uaddr, int futex_op, uint32_t val,
+                 const struct timespec* timeout, uint32_t* uaddr2, uint32_t val3) {
+
+  return syscall(SYS_futex, uaddr, futex_op, val, timeout, uaddr2, val3);
+}
+
+
+namespace dxvk::sync {
+
+  /**
+   * \brief futex based sync implementation
+   */
+  class AtomicSignal {
+
+  public:
+
+    AtomicSignal(const char* name, bool initValue)
+    : m_name(name) {
+      m_flag.store(initValue);
+    }
+
+    ~AtomicSignal() {}
+
+    void wait() {
+
+      while (true) {
+
+        long s;
+        uint32_t one = 1;
+        if (m_flag.compare_exchange_strong(one, 0))
+          return;
+
+        // waits until m_flag becomes != 0
+        s = futex((uint32_t*)&m_flag, FUTEX_WAIT_PRIVATE, 0, NULL, NULL, 0);
+
+        if (unlikely(s == -1 && errno != EAGAIN))
+          Logger::err("futex-FUTEX_WAIT");
+
+      }
+    }
+
+    void signal_one() {
+
+      long s;
+      uint32_t zero = 0;
+      if (m_flag.compare_exchange_strong(zero, 1)) {
+        s = futex((uint32_t*)&m_flag, FUTEX_WAKE_PRIVATE, 1, NULL, NULL, 0);
+
+        if (unlikely(s == -1))
+          Logger::err("futex-FUTEX_WAKE");
+      }
+
+    }
+
+    void signal_all() {
+
+      long s;
+      m_flag.store(1);
+      s = futex((uint32_t*)&m_flag, FUTEX_WAKE_PRIVATE, INT_MAX, NULL, NULL, 0);
+
+      if (unlikely(s == -1))
+          Logger::err("futex-FUTEX_WAKE");
+
+    }
+
+    void clear() {
+      m_flag.store(0);
+    }
+
+  private:
+
+    alignas(64) std::atomic<uint32_t>    m_flag;
+    const char*                          m_name;
+
+  };
+
+}
+
+
+
+#endif


### PR DESCRIPTION
In the low-latency mode, we basically sleep every frame to precisely control the frame start of the render-thread. A large part of that unfortunately needs to be done by spin-waiting.

Putting this spin-wait into another thread lets the frame start with a fresh quantum on its app-thread. It is experimentally verified that this (dependent on the game) reduces frame time jitter - also latency jitter and render thread jitter - by up to ~20% on eevdf, which significantly improves smoothness in those games. A slight fps and/or latency improvement may also be possible.

This is probably generally the case when being run by a fair scheduler, which is the default on most OSes. Scx schedulers don't fall into this category, so threaded sleep may not be needed on those, but neither has it been observed to be disadvantageous.