### PR TITLE
Jitter display

### DIFF
--- a/src/d3d11/d3d11_swapchain.cpp
+++ b/src/d3d11/d3d11_swapchain.cpp
@@ -615,9 +615,10 @@ namespace dxvk {
         m_latencyHud = hud->addItem<hud::HudLatencyItem>("latency", 4);
         FramePacer* framePacer = dynamic_cast<FramePacer*>(m_latency.ptr());
         if (framePacer) {
-          int32_t fpsItemPos = hud->getItemPos<hud::HudFpsItem>();
-          m_renderLatencyHud = hud->addItem<hud::HudRenderLatencyItem>("renderlatency", fpsItemPos+1);
-          m_latencyDetailsHud = hud->addItem<hud::HudLatencyDetailsItem>("latencydetails", fpsItemPos+2);
+          m_renderLatencyHud = reinterpret_cast<hud::HudRenderLatencyItem*>(
+            hud->getItem<hud::HudRenderLatencyItem>().ptr() );
+          m_latencyDetailsHud = reinterpret_cast<hud::HudLatencyDetailsItem*>(
+            hud->getItem<hud::HudLatencyDetailsItem>().ptr() );
         }
       }
     }

--- a/src/d3d11/d3d11_swapchain.cpp
+++ b/src/d3d11/d3d11_swapchain.cpp
@@ -298,6 +298,9 @@ namespace dxvk {
     if (m_renderLatencyHud)
       m_renderLatencyHud->updateLatencyTracker(m_latency);
 
+    if (m_jitterHud)
+      m_jitterHud->updateLatencyTracker(m_latency);
+
     if (m_latencyDetailsHud)
       m_latencyDetailsHud->updateLatencyTracker(m_latency);
 
@@ -617,6 +620,8 @@ namespace dxvk {
         if (framePacer) {
           m_renderLatencyHud = reinterpret_cast<hud::HudRenderLatencyItem*>(
             hud->getItem<hud::HudRenderLatencyItem>().ptr() );
+          m_jitterHud = reinterpret_cast<hud::HudJitterItem*>(
+            hud->getItem<hud::HudJitterItem>().ptr() );
           m_latencyDetailsHud = reinterpret_cast<hud::HudLatencyDetailsItem*>(
             hud->getItem<hud::HudLatencyDetailsItem>().ptr() );
         }

--- a/src/d3d11/d3d11_swapchain.h
+++ b/src/d3d11/d3d11_swapchain.h
@@ -127,6 +127,7 @@ namespace dxvk {
 
     Rc<hud::HudLatencyItem>         m_latencyHud;
     Rc<hud::HudRenderLatencyItem>   m_renderLatencyHud;
+    Rc<hud::HudJitterItem>          m_jitterHud;
     Rc<hud::HudLatencyDetailsItem>  m_latencyDetailsHud;
 
     Rc<DxvkImageView> GetBackBufferView();

--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -940,6 +940,9 @@ namespace dxvk {
     if (m_renderLatencyHud)
       m_renderLatencyHud->updateLatencyTracker(m_latencyTracker);
 
+    if (m_jitterHud)
+      m_jitterHud->updateLatencyTracker(m_latencyTracker);
+
     if (m_latencyDetailsHud)
       m_latencyDetailsHud->updateLatencyTracker(m_latencyTracker);
 
@@ -1095,6 +1098,8 @@ namespace dxvk {
         if (framePacer) {
           m_renderLatencyHud = reinterpret_cast<hud::HudRenderLatencyItem*>(
             hud->getItem<hud::HudRenderLatencyItem>().ptr() );
+          m_jitterHud = reinterpret_cast<hud::HudJitterItem*>(
+            hud->getItem<hud::HudJitterItem>().ptr() );
           m_latencyDetailsHud = reinterpret_cast<hud::HudLatencyDetailsItem*>(
             hud->getItem<hud::HudLatencyDetailsItem>().ptr() );
         }

--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -1093,9 +1093,10 @@ namespace dxvk {
         m_latencyHud = hud->addItem<hud::HudLatencyItem>("latency", 4);
         FramePacer* framePacer = dynamic_cast<FramePacer*>(m_latencyTracker.ptr());
         if (framePacer) {
-          int32_t fpsItemPos = hud->getItemPos<hud::HudFpsItem>();
-          m_renderLatencyHud = hud->addItem<hud::HudRenderLatencyItem>("renderlatency", fpsItemPos+1);
-          m_latencyDetailsHud = hud->addItem<hud::HudLatencyDetailsItem>("latencydetails", fpsItemPos+2);
+          m_renderLatencyHud = reinterpret_cast<hud::HudRenderLatencyItem*>(
+            hud->getItem<hud::HudRenderLatencyItem>().ptr() );
+          m_latencyDetailsHud = reinterpret_cast<hud::HudLatencyDetailsItem*>(
+            hud->getItem<hud::HudLatencyDetailsItem>().ptr() );
         }
       }
 

--- a/src/d3d9/d3d9_swapchain.h
+++ b/src/d3d9/d3d9_swapchain.h
@@ -184,6 +184,7 @@ namespace dxvk {
     Rc<hud::HudClientApiItem>       m_apiHud;
     Rc<hud::HudLatencyItem>         m_latencyHud;
     Rc<hud::HudRenderLatencyItem>   m_renderLatencyHud;
+    Rc<hud::HudJitterItem>          m_jitterHud;
     Rc<hud::HudLatencyDetailsItem>  m_latencyDetailsHud;
 
     std::optional<VkHdrMetadataEXT> m_hdrMetadata;

--- a/src/dxvk/framepacer/dxvk_framepacer.h
+++ b/src/dxvk/framepacer/dxvk_framepacer.h
@@ -4,6 +4,7 @@
 #include "dxvk_frame_sync.h"
 #include "dxvk_latency_markers.h"
 #include "dxvk_latency_stats.h"
+#include "dxvk_jitter_stats.h"
 #include "dxvk_calibrated_device_timestamps.h"
 #include "../dxvk_latency.h"
 #include "../../util/util_time.h"
@@ -202,14 +203,18 @@ namespace dxvk {
     int32_t getLatencyAverage() const
       { return m_latencyAverage.getAverage(); }
 
+    JitterTotal getJitterStats() const
+      { return m_jitterStats.getJitterTotal(); }
+
     const LatencyStats* getGpuBufferStats() const
       { return m_gpuBufferStats.load(); }
 
     const LatencyStats* getPresentStats() const
       { return m_presentationStats.load(); }
 
-    std::atomic< bool > m_enableGpuBufferTracking = { false };
-    std::atomic< bool > m_enableVSyncBufferTracking = { false };
+    std::atomic< bool > m_enabledGpuBufferTracking = { false };
+    std::atomic< bool > m_enabledVSyncBufferTracking = { false };
+    std::atomic< bool > m_enabledJitterTracking = { false };
 
   private:
 
@@ -234,16 +239,34 @@ namespace dxvk {
     }
 
     void trackStats( uint64_t frameId ) {
+      using std::chrono::duration_cast;
+      const LatencyMarkers* m_prev2 = m_latencyMarkersStorage.getConstMarkers(frameId-2);
+      const LatencyMarkers* m_prev = m_latencyMarkersStorage.getConstMarkers(frameId-1);
       const LatencyMarkers* m = m_latencyMarkersStorage.getConstMarkers(frameId);
 
+      if (m_enabledJitterTracking && frameId > m_mode->getFirstFrameId()+2) {
+        JitterEntry e;
+        e.t = m->start;
+        e.frametime  = std::abs( duration_cast<microseconds>( m->start - m_prev->start ).count()
+                               - duration_cast<microseconds>( m_prev->start - m_prev2->start ).count() );
+        e.frametime += std::abs( duration_cast<microseconds>( m->end - m_prev->end ).count()
+                               - duration_cast<microseconds>( m_prev->end - m_prev2->end ).count() );
+        e.frametime >>= 1;
+
+        e.latency = std::abs( m->gpuFinished - m_prev->gpuFinished );
+        e.appThreadLatency = std::abs( m->appThreadFinished - m_prev->appThreadFinished );
+
+        m_jitterStats.push( std::move(e) );
+      }
+
       // will be re-enabled for VK_EXT_present_timing, but for now this isn't accurate enough
-      if (false && m_enableVSyncBufferTracking) {
+      if (false && m_enabledVSyncBufferTracking) {
         if (!m_presentationStats)
           m_presentationStats.store( new LatencyStats(3000) );
         m_presentationStats.load()->push( m->end, m->presentFinished - m->gpuFinished );
       }
 
-      if (m_enableGpuBufferTracking) {
+      if (m_enabledGpuBufferTracking) {
         if (!m_gpuBufferStats)
           m_gpuBufferStats.store( new LatencyStats(3000) );
 
@@ -272,6 +295,7 @@ namespace dxvk {
     std::atomic<LatencyStats*> m_gpuBufferStats = { nullptr };
     std::atomic<LatencyStats*> m_presentationStats = { nullptr };
     LatencyAverage m_latencyAverage;
+    JitterStats m_jitterStats;
 
     CalibratedDeviceTimestamps m_calibratedDeviceTimestamps;
     sync::RingbufferAllocator<VkQueryPool, 256> m_queryPools;

--- a/src/dxvk/framepacer/dxvk_framepacer.h
+++ b/src/dxvk/framepacer/dxvk_framepacer.h
@@ -34,6 +34,10 @@ namespace dxvk {
     void sleepAndBeginFrame(
             uint64_t                  frameId,
             double                    maxFrameRate) override {
+      LatencyMarkers* m = m_latencyMarkersStorage.getMarkers(frameId-1);
+      m->appThreadFinished = std::chrono::duration_cast<microseconds> (
+        high_resolution_clock::now() - m->start).count();
+
       // wait for finished rendering of a previous frame, typically the one before last
       m_frameSync.waitRenderFinished(frameId);
       // potentially wait some more if the cpu gets too much ahead

--- a/src/dxvk/framepacer/dxvk_framepacer_mode.h
+++ b/src/dxvk/framepacer/dxvk_framepacer_mode.h
@@ -60,6 +60,9 @@ namespace dxvk {
     const char* getName() const
       { return m_name; }
 
+    uint64_t getFirstFrameId() const
+      { return m_firstFrameId; }
+
     static bool getDoubleFromEnv( const char* name, double* result );
     static bool getIntFromEnv( const char* name, int* result );
 

--- a/src/dxvk/framepacer/dxvk_jitter_stats.h
+++ b/src/dxvk/framepacer/dxvk_jitter_stats.h
@@ -1,0 +1,84 @@
+#pragma once
+
+#include <stdint.h>
+#include <atomic>
+#include <deque>
+
+#include "../../util/util_time.h"
+
+
+namespace dxvk {
+
+
+  struct JitterEntry {
+
+    using time_point = high_resolution_clock::time_point;
+
+    time_point t;
+
+    int32_t frametime;
+    int32_t latency;
+    int32_t appThreadLatency;
+
+  };
+
+
+  struct JitterTotal {
+
+    int64_t count              = { 0 };
+
+    int64_t frametime          = { 0 };
+    int64_t latency            = { 0 };
+    int64_t appThreadLatency   = { 0 };
+
+  };
+
+
+  class JitterStats {
+  public:
+
+    void push( const JitterEntry&& entry ) {
+
+      int16_t newIndex = (m_curIndex + 1) & 1;
+      JitterTotal& oldTotal = m_jitter[m_curIndex];
+      JitterTotal& newTotal = m_jitter[newIndex];
+
+      m_queue.push_back( std::move(entry) );
+
+      newTotal.count     = oldTotal.count + 1;
+      newTotal.frametime = oldTotal.frametime + entry.frametime;
+      newTotal.latency   = oldTotal.latency + entry.latency;
+      newTotal.appThreadLatency = oldTotal.appThreadLatency + entry.appThreadLatency;
+
+      // remove old items from the queue
+      while (!m_queue.empty() && m_queue.front().t
+        < entry.t - std::chrono::milliseconds (m_duration) ) {
+
+        JitterEntry& e = m_queue.front();
+        --newTotal.count;
+        newTotal.frametime -= e.frametime;
+        newTotal.latency   -= e.latency;
+        newTotal.appThreadLatency -= e.appThreadLatency;
+
+        m_queue.pop_front();
+      }
+
+      m_curIndex.store(newIndex);
+
+    }
+
+    JitterTotal getJitterTotal() const
+      { return m_jitter[m_curIndex.load()]; }
+
+  private:
+
+    inline static constexpr int32_t m_duration = 30000;
+    std::deque<JitterEntry> m_queue;
+
+    JitterTotal m_jitter[2] = { };
+    std::atomic<int16_t> m_curIndex = { 0 };
+
+  };
+
+
+}

--- a/src/dxvk/framepacer/dxvk_latency_markers.h
+++ b/src/dxvk/framepacer/dxvk_latency_markers.h
@@ -21,6 +21,7 @@ namespace dxvk {
     time_point start;
     time_point end;
 
+    int32_t appThreadFinished;
     int32_t csStart;
     int32_t csFinished;
     int32_t cpuFinished;

--- a/src/dxvk/framepacer/dxvk_latency_stats.h
+++ b/src/dxvk/framepacer/dxvk_latency_stats.h
@@ -113,8 +113,6 @@ namespace dxvk {
   class LatencyAverage {
   public:
 
-    using time_point = high_resolution_clock::time_point;
-
     void push( int32_t latency ) {
 
       m_totalLatency -= m_latencies[m_curIndex];

--- a/src/dxvk/hud/dxvk_hud.cpp
+++ b/src/dxvk/hud/dxvk_hud.cpp
@@ -17,6 +17,8 @@ namespace dxvk::hud {
     addItem<HudVersionItem>("version", -1);
     addItem<HudDeviceInfoItem>("devinfo", -1, m_device);
     addItem<HudFpsItem>("fps", -1);
+    addItem<HudRenderLatencyItem>("renderlatency", -1);
+    addItem<HudLatencyDetailsItem>("latencydetails", -1);
     addItem<HudFrameTimeItem>("frametimes", -1, device, &m_renderer);
     addItem<HudSubmissionStatsItem>("submissions", -1, device);
     addItem<HudDrawCallStatsItem>("drawcalls", -1, device);

--- a/src/dxvk/hud/dxvk_hud.cpp
+++ b/src/dxvk/hud/dxvk_hud.cpp
@@ -18,6 +18,7 @@ namespace dxvk::hud {
     addItem<HudDeviceInfoItem>("devinfo", -1, m_device);
     addItem<HudFpsItem>("fps", -1);
     addItem<HudRenderLatencyItem>("renderlatency", -1);
+    addItem<HudJitterItem>("jitter", -1);
     addItem<HudLatencyDetailsItem>("latencydetails", -1);
     addItem<HudFrameTimeItem>("frametimes", -1, device, &m_renderer);
     addItem<HudSubmissionStatsItem>("submissions", -1, device);

--- a/src/dxvk/hud/dxvk_hud.h
+++ b/src/dxvk/hud/dxvk_hud.h
@@ -61,10 +61,10 @@ namespace dxvk::hud {
     }
 
     template<typename T>
-    int32_t getItemPos() {
-      return m_hudItems.getItemPos<T>();
+    Rc<T> getItem() {
+      return m_hudItems.getItem<T>();
     }
-    
+
     /**
      * \brief Creates the HUD
      * 

--- a/src/dxvk/hud/dxvk_hud_item.h
+++ b/src/dxvk/hud/dxvk_hud_item.h
@@ -132,12 +132,13 @@ namespace dxvk::hud {
     }
 
     template<typename T>
-    int32_t getItemPos() {
+    Rc<T> getItem() {
       for (int i=0; i<(int)m_items.size(); ++i) {
-        if (dynamic_cast<T*>(m_items[i].ptr()))
-          return i;
+        T* item = dynamic_cast<T*>(m_items[i].ptr());
+        if (item)
+          return Rc<T> (item);
       }
-      return -1;
+      return Rc<T> (nullptr);
     }
 
   private:

--- a/src/dxvk/hud/dxvk_hud_item.h
+++ b/src/dxvk/hud/dxvk_hud_item.h
@@ -291,6 +291,44 @@ namespace dxvk::hud {
 
 
   /**
+   * \brief HUD item to display jitter
+   */
+  class HudJitterItem : public HudItem {
+    constexpr static int64_t UpdateInterval = 500'000;
+  public:
+
+    HudJitterItem();
+
+    ~HudJitterItem();
+
+    void updateLatencyTracker( const Rc<DxvkLatencyTracker>& tracker ) {
+      m_tracker = tracker;
+    }
+
+    void update(dxvk::high_resolution_clock::time_point time);
+
+    HudPos render(
+      const Rc<DxvkCommandList>&ctx,
+      const HudPipelineKey&     key,
+      const HudOptions&         options,
+            HudRenderer&        renderer,
+            HudPos              position);
+
+  private:
+
+    Rc<DxvkLatencyTracker> m_tracker;
+
+    dxvk::high_resolution_clock::time_point m_lastUpdate
+      = dxvk::high_resolution_clock::now();
+
+    std::string m_frametime;
+    std::string m_latency;
+    std::string m_appThread;
+
+  };
+
+
+  /**
    * \brief HUD item to display latency details, buffers, etc.
    */
   class HudLatencyDetailsItem : public HudItem {

--- a/src/dxvk/hud/dxvk_hud_item_latency.cpp
+++ b/src/dxvk/hud/dxvk_hud_item_latency.cpp
@@ -3,10 +3,13 @@
 
 namespace dxvk::hud {
 
+
   HudRenderLatencyItem::HudRenderLatencyItem() { }
   HudRenderLatencyItem::~HudRenderLatencyItem() { }
 
+
   void HudRenderLatencyItem::update(dxvk::high_resolution_clock::time_point time) {
+
     const Rc<DxvkLatencyTracker> tracker = m_tracker;
     const FramePacer* framePacer = dynamic_cast<FramePacer*>( tracker.ptr() );
     if (!framePacer)
@@ -20,6 +23,7 @@ namespace dxvk::hud {
       int32_t latency = framePacer->getLatencyAverage();
       m_latency = str::format(latency / 1000, ".", (latency/100) % 10, " ms");
     }
+
   }
 
 
@@ -40,8 +44,74 @@ namespace dxvk::hud {
   }
 
 
+  HudJitterItem::HudJitterItem() { }
+  HudJitterItem::~HudJitterItem() { }
+
+
+  void HudJitterItem::update(dxvk::high_resolution_clock::time_point time) {
+
+    const Rc<DxvkLatencyTracker> tracker = m_tracker;
+    FramePacer* framePacer = dynamic_cast<FramePacer*>( tracker.ptr() );
+    if (!framePacer)
+      return;
+
+    if (!framePacer->m_enabledJitterTracking)
+      framePacer->m_enabledJitterTracking.store(true);
+
+    auto elapsed = std::chrono::duration_cast<std::chrono::microseconds>(time - m_lastUpdate);
+
+    if (elapsed.count() >= UpdateInterval) {
+      m_lastUpdate = time;
+
+      JitterTotal jitter = framePacer->getJitterStats();
+
+      if (jitter.count) {
+        float count_inv = 1.0/jitter.count;
+        jitter.frametime *= count_inv;
+        jitter.latency   *= count_inv;
+        jitter.appThreadLatency *= count_inv;
+
+        jitter.frametime = std::min( (int64_t) 9999, jitter.frametime );
+        jitter.latency   = std::min( (int64_t) 9999, jitter.latency );
+        jitter.appThreadLatency = std::min( (int64_t) 9999, jitter.appThreadLatency );
+      }
+
+      m_frametime = str::format( jitter.frametime );
+      m_latency   = str::format( jitter.latency );
+      m_appThread = str::format( jitter.appThreadLatency );
+    }
+  }
+
+
+  HudPos HudJitterItem::render(
+    const Rc<DxvkCommandList>&ctx,
+    const HudPipelineKey&     key,
+    const HudOptions&         options,
+          HudRenderer&        renderer,
+          HudPos              position) {
+
+    constexpr int w = 12;
+    position.y += 12;
+
+    renderer.drawText(16, position, 0xff40ffffu, "Jitter (us):");
+    position.y += 16;
+    int x = 2 * w;
+
+    renderer.drawText(16, { position.x + x, position.y }, 0xff40ffffu, "ft"); x += 3*w;
+    renderer.drawText(16, { position.x + x, position.y }, 0xffffffffu, m_frametime); x += (m_frametime.size()+1)*w;
+    renderer.drawText(16, { position.x + x, position.y }, 0xff40ffffu, "lat"); x += 4*w;
+    renderer.drawText(16, { position.x + x, position.y }, 0xffffffffu, m_latency); x += (m_latency.size()+1)*w;
+    renderer.drawText(16, { position.x + x, position.y }, 0xff40ffffu, "atl"); x += 4*w;
+    renderer.drawText(16, { position.x + x, position.y }, 0xffffffffu, m_appThread);
+
+    position.y += 8;
+    return position;
+  }
+
+
   HudLatencyDetailsItem::HudLatencyDetailsItem() { }
   HudLatencyDetailsItem::~HudLatencyDetailsItem() { }
+
 
   void HudLatencyDetailsItem::update(dxvk::high_resolution_clock::time_point time) {
 

--- a/src/dxvk/hud/dxvk_hud_item_latency.cpp
+++ b/src/dxvk/hud/dxvk_hud_item_latency.cpp
@@ -50,10 +50,10 @@ namespace dxvk::hud {
     if (!framePacer)
       return;
 
-    if (!framePacer->m_enableGpuBufferTracking)
-      framePacer->m_enableGpuBufferTracking.store(true);
-    if (!framePacer->m_enableVSyncBufferTracking && framePacer->getFramePacerMode()->getPresentMode() == VK_PRESENT_MODE_FIFO_KHR)
-      framePacer->m_enableVSyncBufferTracking.store(true);
+    if (!framePacer->m_enabledGpuBufferTracking)
+      framePacer->m_enabledGpuBufferTracking.store(true);
+    if (!framePacer->m_enabledVSyncBufferTracking && framePacer->getFramePacerMode()->getPresentMode() == VK_PRESENT_MODE_FIFO_KHR)
+      framePacer->m_enabledVSyncBufferTracking.store(true);
 
     auto elapsed = std::chrono::duration_cast<std::chrono::microseconds>(time - m_lastUpdate);
 


### PR DESCRIPTION
Useful to evaluate smoothness performance -- from the game, the system, schedulers, etc.
Jitter values are averaged over 30 seconds to display a stable value, and is measured for frametime, latency and app-thread latency.

App-thread (render-thread) latency may be important for smoothness when the game for example is taking timestamps to optimize synchronization from input/simulation to the render thread. It may also be important to keep this thread stable when the game is performing other functionality within this thread.

It's interesting that dxvk-low-latency profits pretty strongly from scx schedulers, which often show half the jitter of eevdf, which then also can be seen as smoothness gain, sometimes pretty obviously. Depending on the game, the optimal scheduler choice may vary. 